### PR TITLE
Remove the ambiguous [] operator from ke::AutoArray.

### DIFF
--- a/include/am-utility.h
+++ b/include/am-utility.h
@@ -158,14 +158,8 @@ class AutoArray
     T *take() {
         return ReturnAndVoid(t_);
     }
-    T *operator *() const {
+    T &operator *() const {
         return t_;
-    }
-    T &operator [](size_t index) {
-      return t_[index];
-    }
-    const T &operator [](size_t index) const {
-      return t_[index];
     }
     operator T *() const {
         return t_;


### PR DESCRIPTION
On older versions of gcc (say, 4.5) this operator causes an ambiguity if the index is a signed int. The compiler can choose either the implicit cast to `T *`, or it can use the `[]` overload. Apparently the fix is to just remove the `[]` overload and let the implicit cast do its thing.
