### PR TITLE
POSIX threading fixes

### DIFF
--- a/include/am-thread-posix.h
+++ b/include/am-thread-posix.h
@@ -183,6 +183,7 @@ class Thread
     if (!Succeeded())
       return;
     pthread_join(thread_, nullptr);
+    initialized_ = false;
   }
 
  private:

--- a/include/am-thread-posix.h
+++ b/include/am-thread-posix.h
@@ -174,6 +174,11 @@ class Thread
     if (!initialized_)
       delete data;
   }
+  ~Thread() {
+    if (!Succeeded())
+      return;
+    pthread_detach(thread_);
+  }
 
   bool Succeeded() const {
     return initialized_;


### PR DESCRIPTION
We currently leak threads if Join() is never called (such as IThreader threads using Thread_AutoRelease or the simple MakeThread overload). Also, calling Join() more than once could cause a crash / the wrong thread to be joined. This changes the POSIX thread implementation to match the behaviour of the Windows one and let the OS clean up resources if the Thread instance is released.

@dvander