### PR TITLE
dlclose crashes when given NULL.

### DIFF
--- a/amtl/os/am-shared-library.h
+++ b/amtl/os/am-shared-library.h
@@ -65,6 +65,9 @@ class SharedLib : public Refcounted<SharedLib>
 #endif
   }
   ~SharedLib() {
+    if (lib_ == nullptr)
+      return;
+
 #if defined(KE_WINDOWS)
     FreeLibrary(lib_);
 #else


### PR DESCRIPTION
ke::SharedLib will crash on linux (maybe posix) if it can't find/open the library. This adds a branch in the destructor to prevent such an occurrence.

#0  0xf7ff08d7 in ?? () from /lib/ld-linux.so.2
No symbol table info available.
#1  0xf7f80dd2 in ?? () from /lib/libdl.so.2
No symbol table info available.
#2  0xf7feaf56 in ?? () from /lib/ld-linux.so.2
No symbol table info available.
#3  0xf7f8138c in ?? () from /lib/libdl.so.2
No symbol table info available.
#4  0xf7f80e08 in dlclose () from /lib/libdl.so.2
No symbol table info available.
#5  0xea6e6a48 in ke::SharedLib::~SharedLib (this=0x83ef5c0, __in_chrg=<optimized out>) at /home/plagueshell/sourcemod/public/amtl/amtl/os/am-shared-library.h:74
No locals.
