### PR TITLE
Fix AMTL against CRT library memory leak detection on debug builds.

### DIFF
--- a/amtl/am-allocator-policies.h
+++ b/amtl/am-allocator-policies.h
@@ -49,11 +49,19 @@ class SystemAllocatorPolicy
     }
 
   public:
-    void free(void *memory) {
+    void am_free(void *memory) {
+#if defined(_DEBUG) && defined(_CRTDBG_MAP_ALLOC)
+      free(memory);
+#else
       ::free(memory);
+#endif
     }
-    void *malloc(size_t bytes) {
+    void *am_malloc(size_t bytes) {
+#if defined(_DEBUG) && defined(_CRTDBG_MAP_ALLOC)
+      void *ptr = malloc(bytes);
+#else
       void *ptr = ::malloc(bytes);
+#endif
       if (!ptr)
         reportOutOfMemory();
       return ptr;

--- a/amtl/am-deque.h
+++ b/amtl/am-deque.h
@@ -202,7 +202,7 @@ class Deque : public AllocPolicy
     }
 
     size_t new_maxlength = maxlength_ ? maxlength_ * 2 : 8;
-    T *new_buffer = (T *)this->malloc(sizeof(T) * new_maxlength);
+    T *new_buffer = (T *)this->am_malloc(sizeof(T) * new_maxlength);
     if (!new_buffer)
       return false;
 
@@ -218,7 +218,7 @@ class Deque : public AllocPolicy
       last_ = last_ + (maxlength_ - first_);
       first_ = 0;
     }
-    this->free(buffer_);
+    this->am_free(buffer_);
 
     buffer_ = new_buffer;
     maxlength_ = new_maxlength;
@@ -242,7 +242,7 @@ class Deque : public AllocPolicy
       for (size_t i = 0; i < last_; i++)
         buffer_[i].~T();
     }
-    this->free(buffer_);
+    this->am_free(buffer_);
   }
 
  private:

--- a/amtl/am-fixedarray.h
+++ b/amtl/am-fixedarray.h
@@ -41,7 +41,7 @@ class FixedArray : public AllocPolicy
  public:
   FixedArray(size_t length, AllocPolicy = AllocPolicy()) {
     length_ = length;
-    data_ = (T *)this->malloc(sizeof(T) * length_);
+    data_ = (T *)this->am_malloc(sizeof(T) * length_);
     if (!data_)
       return;
 
@@ -51,7 +51,7 @@ class FixedArray : public AllocPolicy
   ~FixedArray() {
     for (size_t i = 0; i < length_; i++)
       data_[i].~T();
-    this->free(data_);
+    this->am_free(data_);
   }
 
   // This call may be skipped if the allocator policy is infallible.

--- a/amtl/am-hashtable.h
+++ b/amtl/am-hashtable.h
@@ -147,7 +147,7 @@ class HashTable : public AllocPolicy
   Entry *createTable(uint32_t capacity) {
     assert(capacity <= kMaxCapacity);
 
-    Entry *table = (Entry *)this->malloc(capacity * sizeof(Entry));
+    Entry *table = (Entry *)this->am_malloc(capacity * sizeof(Entry));
     if (!table)
       return nullptr;
 
@@ -269,7 +269,7 @@ class HashTable : public AllocPolicy
       }
       oldEntry.destruct();
     }
-    this->free(oldTable);
+    this->am_free(oldTable);
 
     return true;
   }
@@ -380,7 +380,7 @@ class HashTable : public AllocPolicy
   {
     for (uint32_t i = 0; i < capacity_; i++)
       table_[i].destruct();
-    this->free(table_);
+    this->am_free(table_);
   }
 
   bool init(size_t capacity = 0) {

--- a/amtl/am-linkedlist.h
+++ b/amtl/am-linkedlist.h
@@ -122,7 +122,7 @@ public:
 
   template <typename U>
   Node *allocNode(U &&obj) {
-    Node *node = (Node *)this->malloc(sizeof(Node));
+    Node *node = (Node *)this->am_malloc(sizeof(Node));
     if (!node)
       return nullptr;
     new (&node->obj) T(ke::Forward<U>(obj));
@@ -131,7 +131,7 @@ public:
 
   void freeNode(Node *node) {
     node->obj.~T();
-    this->free(node);
+    this->am_free(node);
   }
 
  private:

--- a/amtl/am-vector.h
+++ b/amtl/am-vector.h
@@ -202,7 +202,7 @@ class Vector : public AllocPolicy
   }
   void zap() {
     destruct_live();
-    this->free(data_);
+    this->am_free(data_);
   }
   void reset() {
     data_ = nullptr;
@@ -243,11 +243,11 @@ class Vector : public AllocPolicy
       new_maxsize *= 2;
     }
 
-    T* newdata = (T*)this->malloc(sizeof(T) * new_maxsize);
+    T* newdata = (T*)this->am_malloc(sizeof(T) * new_maxsize);
     if (newdata == nullptr)
       return false;
     MoveRange<T>(newdata, data_, nitems_);
-    this->free(data_);
+    this->am_free(data_);
 
     data_ = newdata;
     maxsize_ = new_maxsize;

--- a/tests/runner.h
+++ b/tests/runner.h
@@ -108,15 +108,23 @@ class FallibleMalloc
   {
   }
 
-  void *malloc(size_t amount) {
+  void *am_malloc(size_t amount) {
     if (shouldOutOfMemory_) {
       reportOutOfMemory();
       return nullptr;
     }
+#if defined(_DEBUG) && defined(_CRTDBG_MAP_ALLOC)
+    return malloc(amount);
+#else
     return ::malloc(amount);
+#endif
   }
-  void free(void *p) {
+  void am_free(void *p) {
+#if defined(_DEBUG) && defined(_CRTDBG_MAP_ALLOC)
+    return free(p);
+#else
     return ::free(p);
+#endif
   }
   void reportOutOfMemory() {
     ooms_++;


### PR DESCRIPTION
When compiling something with the CRT memory leak detection enabled on debug builds, MSCV compile errors due to free and malloc being defines.