### PR TITLE
Fix memory leak in remove.

### DIFF
--- a/amtl/am-vector.h
+++ b/amtl/am-vector.h
@@ -94,6 +94,9 @@ class Vector : public AllocPolicy
   // Shift all elements at the given position down, removing the given
   // element. This is a linear-time operation.
   void remove(size_t at) {
+    assert(at < length());
+    if (length() > 1)
+      data_[at].~T(); //Make sure value AT index we want to remove frees it's memory(if we got more then 1 value).
     for (size_t i = at; i < length() - 1; i++)
       data_[i] = ke::Move(data_[i + 1]);
     pop();

--- a/tests/test-vector.cpp
+++ b/tests/test-vector.cpp
@@ -38,6 +38,7 @@ static size_t sCopyCtors = 0;
 static size_t sMovingCtors = 0;
 static size_t sMovedDtors = 0;
 static size_t sDtors = 0;
+static size_t sNDtors = 0;
 
 namespace {
 
@@ -58,6 +59,43 @@ class BasicThing
   }
 };
 
+class BasicRemoveThing
+{
+  public:
+    BasicRemoveThing() :
+      moved_(false),
+      count_(true)
+    {
+    }
+    BasicRemoveThing(bool count) :
+      moved_(false),
+      count_(count)
+    {
+    }
+    BasicRemoveThing(BasicRemoveThing &&other)
+    {
+      assert(!other.moved_);
+      count_ = other.count_;
+      moved_ = false;
+      other.moved_ = true;
+    }
+    BasicRemoveThing &operator =(BasicRemoveThing &&other) {
+      assert(!other.moved_);
+      count_ = other.count_;
+      moved_ = false;
+      other.moved_ = true;
+      return *this;
+    }
+    ~BasicRemoveThing()
+    {
+      if (count_ && !moved_)
+        sNDtors++;
+    }
+  private:
+    bool moved_;
+    bool count_;
+};
+
 class MovingThing
 {
  public:
@@ -76,7 +114,7 @@ class MovingThing
   ~MovingThing()
   {
     sDtors++;
-    if (moved_)
+    if (!moved_)
       sMovedDtors++;
   }
   MovingThing &operator =(MovingThing &&other) {
@@ -103,6 +141,32 @@ class TestVector : public Test
   TestVector()
    : Test("Vector")
   {
+  }
+  
+  bool testRemove()
+  {
+    // This test requires us to verify the destructor is only called once, even after destruction of vector itself.
+    {
+      Vector<BasicRemoveThing> vector;
+      vector.append(ke::Move(BasicRemoveThing()));
+      vector.remove(0);
+    }
+    
+    if (!check(sNDtors == 1, "Destructor only called once"))
+      return false;
+    
+    // This test requires us to verify the destructor is only called once, 2 values in, even after destruction of vector itself.
+    {
+      Vector<BasicRemoveThing> vector;
+      vector.append(ke::Move(BasicRemoveThing()));
+      vector.append(ke::Move(BasicRemoveThing(false)));
+      vector.remove(0);
+    }
+    
+    if (!check(sNDtors == 2, "Destructor only called once"))
+      return false;
+  
+    return true;
   }
 
   bool testInts()
@@ -309,6 +373,8 @@ class TestVector : public Test
   bool Run() override
   {
     if (!testInts())
+      return false;
+    if (!testRemove())
       return false;
     if (!testDestructors())
       return false;


### PR DESCRIPTION
AMTL's vector class never accounted for types where internally for them
they can have pointers that need memory released.