### PR TITLE
VS 2015 has support for constexpr and noexcept

### DIFF
--- a/amtl/am-cxx.h
+++ b/amtl/am-cxx.h
@@ -133,6 +133,10 @@
 # if _MSC_VER == 1800 && _MSC_FULL_VER == 180021114
 #  define KE_CXX_HAS_CONSTEXPR
 # endif
+# if _MSC_VER >= 1900
+#  define KE_CXX_HAS_CONSTEXPR
+#  define KE_CXX_HAS_NOEXCEPT
+# endif
 #else
 # error Unrecognized compiler.
 #endif


### PR DESCRIPTION
From:
https://msdn.microsoft.com/en-us/library/hh409293.aspx?f=255&MSPPError=-2147217396#BK_Compiler
constexpr Create compile-time constant variables, functions and
user-defined types. (C++11)
noexcept The noexcept operator can now be used to check whether an
expression might throw an exception. The noexcept specifier can now be
used to specify that a function does not throw exceptions. (C++11)

Note: Left in constexpr check for a specific VS version as the VS 2013 community edition I have installed doesn't support constexpr