### PR TITLE
Fix AMBuildScript

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -7,21 +7,20 @@ class KEConfig(object):
     pass
 
   def configure(self):
-    cfg = builder.DetectCompilers()
-    cxx = cfg.cxx
+    cxx = builder.DetectCompilers()
 
-    if cfg.version < 'clang-3.0' or cfg.version < 'apple-clang-3.0':
+    if cxx.version < 'clang-3.0' or cxx.version < 'apple-clang-3.0':
       raise Exception('AMTL requires clang 3.0 or higher.')
-    if cfg.version < 'gcc-4.5':
+    if cxx.version < 'gcc-4.5':
       raise Exception('AMTL requires GCC 4.5 or higher.')
-    if cfg.version < 'msvc-1600':
+    if cxx.version < 'msvc-1600':
       raise Exception('AMTL requires Visual Studio 2010 (CL 16.00) or higher.')
 
     if cxx.like('gcc'):
       std = getattr(builder.options, 'std', None)
       if std is not None:
-          cfg.cxxflags += ['-std={0}'.format(std)]
-      cfg.defines += [
+          cxx.cxxflags += ['-std={0}'.format(std)]
+      cxx.defines += [
         'stricmp=strcasecmp',
         '_stricmp=strcasecmp',
         '_snprintf=snprintf',
@@ -29,57 +28,57 @@ class KEConfig(object):
         'HAVE_STDINT_H',
         'GNUC',
       ]
-      cfg.cflags += [
+      cxx.cflags += [
         '-pipe',
         '-Wall',
         '-Werror',
       ]
-      if cxx.name == 'gcc':
+      if cxx.vendor == 'gcc':
         if cxx.version >= '4.7':
-          cfg.cxxflags += ['-std=c++11']
+          cxx.cxxflags += ['-std=c++11']
         elif cxx.version >= '4.3':
-          cfg.cxxflags += ['-std=c++0x']
+          cxx.cxxflags += ['-std=c++0x']
       else:
-        cfg.cxxflags += ['-std=c++11']
+        cxx.cxxflags += ['-std=c++11']
 
-      cfg.linkflags += ['-lpthread']
+      cxx.linkflags += ['-lpthread']
       if builder.target_platform != 'mac':
-        cfg.linkflags += ['-lrt']
+        cxx.linkflags += ['-lrt']
 
-      have_gcc = cxx.name == 'gcc'
-      have_clang = cxx.name == 'clang'
-      if have_clang or (have_gcc and cxx.majorVersion >= 4):
-        cfg.cflags += ['-fvisibility=hidden']
-        cfg.cxxflags += ['-fvisibility-inlines-hidden']
+      have_gcc = cxx.vendor == 'gcc'
+      have_clang = cxx.vendor == 'clang'
+      if have_clang or (have_gcc and cxx.cxx.majorVersion >= 4):
+        cxx.cflags += ['-fvisibility=hidden']
+        cxx.cxxflags += ['-fvisibility-inlines-hidden']
 
-      cfg.cxxflags += [
+      cxx.cxxflags += [
         '-fno-exceptions',
         '-fno-threadsafe-statics',
       ]
 
       if have_gcc:
-        cfg.cflags += ['-mfpmath=sse']
-    elif cxx.name == 'msvc':
+        cxx.cflags += ['-mfpmath=sse']
+    elif cxx.vendor == 'msvc':
       if builder.options.debug == '1':
-        cfg.cflags += ['/MTd']
-        cfg.linkflags += ['/NODEFAULTLIB:libcmt']
+        cxx.cflags += ['/MTd']
+        cxx.linkflags += ['/NODEFAULTLIB:libcmt']
       else:
-        cfg.cflags += ['/MT']
-      cfg.defines += [
+        cxx.cflags += ['/MT']
+      cxx.defines += [
         '_CRT_SECURE_NO_DEPRECATE',
         '_CRT_SECURE_NO_WARNINGS',
         '_CRT_NONSTDC_NO_DEPRECATE',
         '_ITERATOR_DEBUG_LEVEL=0',
       ]
-      cfg.cflags += [
+      cxx.cflags += [
         '/W3',
       ]
-      cfg.cxxflags += [
+      cxx.cxxflags += [
         '/EHsc',
         '/GR-',
         '/TP',
       ]
-      cfg.linkflags += [
+      cxx.linkflags += [
         '/MACHINE:X86',
         'kernel32.lib',
         'user32.lib',
@@ -97,44 +96,44 @@ class KEConfig(object):
 
     # Optimization
     if builder.options.opt == '1':
-      cfg.defines += ['NDEBUG']
+      cxx.defines += ['NDEBUG']
       if cxx.like('gcc'):
-        cfg.cflags += ['-O3']
-      elif cxx.like('msvc'):
-        cfg.cflags += ['/Ox']
-        cfg.linkflags += ['/OPT:ICF', '/OPT:REF']
+        cxx.cflags += ['-O3']
+      elif cxx.vendor == 'msvc':
+        cxx.cflags += ['/Ox']
+        cxx.linkflags += ['/OPT:ICF', '/OPT:REF']
 
     # Debugging
     if builder.options.debug == '1':
-      cfg.defines += ['DEBUG', '_DEBUG']
-      if cxx.like('msvc'):
-        cfg.cflags += ['/Od', '/RTC1']
+      cxx.defines += ['DEBUG', '_DEBUG']
+      if cxx.vendor == 'msvc':
+        cxx.cflags += ['/Od', '/RTC1']
         if cxx.version >= 1600:
-          cfg.cflags += ['/d2Zi+']
+          cxx.cflags += ['/d2Zi+']
 
     # This needs to be after our optimization flags which could otherwise disable it.
-    if cxx.name == 'msvc':
+    if cxx.vendor == 'msvc':
       # Don't omit the frame pointer.
-      cfg.cflags += ['/Oy-']
+      cxx.cflags += ['/Oy-']
 
     # Platform-specifics
     if builder.target_platform == 'linux':
-      cfg.defines += ['_LINUX', 'POSIX']
-      if cxx.name == 'gcc':
-        cfg.linkflags += ['-static-libgcc']
-      elif cxx.name == 'clang':
-        cfg.linkflags += ['-lgcc_eh']
+      cxx.defines += ['_LINUX', 'POSIX']
+      if cxx.vendor == 'gcc':
+        cxx.linkflags += ['-static-libgcc']
+      elif cxx.vendor == 'clang':
+        cxx.linkflags += ['-lgcc_eh']
     elif builder.target_platform == 'mac':
-      cfg.defines += ['OSX', '_OSX', 'POSIX']
-      cfg.cflags += ['-mmacosx-version-min=10.5']
-      cfg.linkflags += [
+      cxx.defines += ['OSX', '_OSX', 'POSIX']
+      cxx.cflags += ['-mmacosx-version-min=10.5']
+      cxx.linkflags += [
         '-mmacosx-version-min=10.5',
         '-lstdc++',
         '-stdlib=libstdc++',
       ]
-      cfg.cxxflags += ['-stdlib=libstdc++']
+      cxx.cxxflags += ['-stdlib=libstdc++']
     elif builder.target_platform == 'windows':
-      cfg.defines += ['WIN32', '_WINDOWS']
+      cxx.defines += ['WIN32', '_WINDOWS']
 
   def Program(self, context, name):
     compiler = context.compiler.clone()


### PR DESCRIPTION
VS gen breaks on old format of the AMBuildScript, this PR fixes that by changing cfg -> cxx and discarding the line cxx = cfg.cxx