### PR TITLE
Introduce a third Lambda variant.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -35,12 +35,19 @@ class KEConfig(object):
         '-Werror',
       ]
       if cxx.name == 'gcc':
-        if cxx.version >= '4.7':
+        if cxx.version >= '4.9':
+          cfg.cxxflags += ['-std=c++14']
+        elif cxx.version >= '4.7':
           cfg.cxxflags += ['-std=c++11']
         elif cxx.version >= '4.3':
           cfg.cxxflags += ['-std=c++0x']
       else:
-        cfg.cxxflags += ['-std=c++11']
+        if cxx.version >= '3.5':
+          cfg.cxxflags += ['-std=c++14']
+        elif cxx.version >= '3.3':
+          cfg.cxxflags += ['-std=c++1y']
+        else:
+          cfg.cxxflags += ['-std=c++11']
 
       cfg.linkflags += ['-lpthread']
       if builder.target_platform != 'mac':

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ iterator is abandoned. However, the table must stay alive for as long as the ite
 
 ### Functions and Lambdas (am-function.h)
 
-AMTL provides two replacements for `std::function`. The first, `ke::Lambda`, is roughly identical
+AMTL provides three replacements for `std::function`. The first, `ke::Lambda`, is roughly identical
 to `std::function` in that it represents any callable object of a given signature. It can hold a
 functor, C-style static function, a C++11-lambda, or any other callable object.
 
@@ -192,6 +192,18 @@ An example of how each is declared:
       return value;
     };
     FuncPtr<int()> callback2(&fn);
+
+Finally, AMTL provides a third variant, called Function. This version is similar to Lambda except
+that it does not provide any copy constructors. This is useful since, due to implementation reasons,
+Lambda cannot be used with C++14 move captures if the resulting type does not have a non-move copy
+constructor. For example,
+
+    Vector<int> v;
+    Function<void()> fn = [v = Move(v)]() -> void {};
+    Lambda<void()> fn = [v = Move(v)]() -> void {};
+
+The first capture, using `Function`, will succeed. The second, using `Lambda`, will fail, since
+`Lambda` does not support captures with no copy constructor.
 
 ### HashMap (am-hashmap.h)
 

--- a/amtl/am-thread-posix.h
+++ b/amtl/am-thread-posix.h
@@ -162,13 +162,13 @@ class ConditionVariable : public Lockable
 class Thread
 {
   struct ThreadData {
-    ke::Lambda<void()> callback;
+    ke::Function<void()> callback;
     char name[17];
   };
  public:
-  Thread(ke::Lambda<void()>&& callback, const char *name = nullptr) {
+  Thread(ke::Function<void()>&& callback, const char *name = nullptr) {
     ThreadData *data = new ThreadData;
-    data->callback = callback;
+    data->callback = ke::Move(callback);
     snprintf(data->name, sizeof(data->name), "%s", name ? name : "");
 
     initialized_ = (pthread_create(&thread_, nullptr, Main, data) == 0);

--- a/amtl/am-thread-windows.h
+++ b/amtl/am-thread-windows.h
@@ -115,8 +115,8 @@ class ConditionVariable : public Lockable
 class Thread
 {
  public:
-  Thread(ke::Lambda<void()>&& callback, const char *name = nullptr) {
-    auto ptr = new ke::Lambda<void()>(ke::Move(callback));
+  Thread(ke::Function<void()>&& callback, const char *name = nullptr) {
+    auto ptr = new ke::Function<void()>(ke::Move(callback));
     thread_ = CreateThread(nullptr, 0, MainCallback, ptr, 0, nullptr);
     if (!thread_)
       delete ptr;

--- a/tests/test-callable.cpp
+++ b/tests/test-callable.cpp
@@ -28,6 +28,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include <am-function.h>
+#include <am-vector.h>
 #include "runner.h"
 
 using namespace ke;
@@ -250,6 +251,22 @@ class TestCallable : public Test
     return true;
   }
 
+  bool testMoveUncopyable() {
+    Vector<int> v;
+
+    auto lambda = [v = Move(v)]() -> size_t {
+      return v.length();
+    };
+
+    v.append(10);
+    Function<size_t()> f = ke::Move(lambda);
+
+    if (!check(f() == 0, "f() should have returned 0"))
+      return false;
+
+    return true;
+  }
+
   bool Run() override
   {
     if (!testLambdaBasic())
@@ -259,6 +276,8 @@ class TestCallable : public Test
     if (!testMove())
       return false;
     if (!testFuncPtr())
+      return false;
+    if (!testMoveUncopyable())
       return false;
     return true;
   };


### PR DESCRIPTION
C++14 allows us to capture lambda variables, via syntax like this:

    auto lambda = [var = std::move(thing)] () -> void { ... }

However, AMTL's `Lambda` implements a copy constructor. Since it must delegate the copy to a virtual base class, the compiler has no way of automatically excluding this copy. If you capture something like AMTL's `Vector`, the compiler will error, even if done by move assignment. For example,

    Vector<int> v;
    Lambda<void()> f = [v = Move(v)]() -> void {};

Will fail, because the AMTL wrapper for the compiler-generated lambda type must implement a virtual copy function. STL suffers from the same problem; this will not compile:

    std::unique_ptr<int> p = std::make_unique<int>(5);
    std::function<void()> f = [p = std::move(p)] () -> void {};

There are two ways I guess we could try to solve this in AMTL. One would be to change `Lambda` to share+refcount the underlying lambda wrapper. We'd lose the inline storage optimization, I can't see a way we could keep that. In addition to more `malloc` calls, it'd also mean that captures are never copied when `Lambdas` are copied. This is the route Mozilla takes.

Another option is to remove the copy functionality of `Lambda` altogether. It's not really used in AM projects, except when we just forget to call `Move`. This pattern, for example:

    auto lambda = []() -> void {
        ...
    };
    DoSomethingWithVeryLongFunctionName(lambda);

Here a copy is involved since the lambda and its usage have been split into two lines for readability. But here, `Move` can be used.

I don't really know what the best thing to do is, so for now, I'm introducing a new type called `Function`. It is exactly `Lambda` except it doesn't support copying at all. This way old projects can upgrade AMTL without breaking.