### PR TITLE
Fix constructors of different types coercing to AllocPolicy.

### DIFF
--- a/amtl/am-deque.h
+++ b/amtl/am-deque.h
@@ -40,12 +40,12 @@
 namespace ke {
 
 template <typename T, typename AllocPolicy = SystemAllocatorPolicy>
-class Deque : public AllocPolicy
+class Deque : private AllocPolicy
 {
   static const size_t kInvalidIndex = ~size_t(0);
 
  public:
-  Deque(AllocPolicy = AllocPolicy())
+  explicit Deque(AllocPolicy = AllocPolicy())
    : buffer_(NULL),
      maxlength_(0),
      first_(0),
@@ -53,7 +53,8 @@ class Deque : public AllocPolicy
   {
   }
   Deque(Deque &&other)
-   : buffer_(other.buffer_),
+   : AllocPolicy(Move(other)),
+     buffer_(other.buffer_),
      maxlength_(other.maxlength_),
      first_(other.first_),
      last_(other.last_)
@@ -159,8 +160,8 @@ class Deque : public AllocPolicy
   }
 
  private:
-  Deque(const Deque<T> &other) = delete;
-  Deque &operator =(const Deque<T> &other) = delete;
+  Deque(const Deque &other) = delete;
+  Deque &operator =(const Deque &other) = delete;
 
   // Return the next value of first_.
   size_t ensureCanPrepend() {

--- a/amtl/am-fixedarray.h
+++ b/amtl/am-fixedarray.h
@@ -36,7 +36,7 @@
 namespace ke {
 
 template <typename T, typename AllocPolicy = SystemAllocatorPolicy>
-class FixedArray : public AllocPolicy
+class FixedArray : private AllocPolicy
 {
  public:
   FixedArray(size_t length, AllocPolicy = AllocPolicy()) {

--- a/amtl/am-hashmap.h
+++ b/amtl/am-hashmap.h
@@ -49,7 +49,7 @@ template <typename K,
           typename V,
           typename HashPolicy,
           typename AllocPolicy = SystemAllocatorPolicy>
-class HashMap : public AllocPolicy
+class HashMap : private AllocPolicy
 {
  private:
   struct Entry
@@ -93,8 +93,8 @@ class HashMap : public AllocPolicy
   typedef HashTable<Policy, AllocPolicy> Internal;
 
  public:
-  HashMap(AllocPolicy ap = AllocPolicy())
-    : table_(ap)
+  explicit HashMap(AllocPolicy ap = AllocPolicy())
+   : table_(ap)
   {
   }
 

--- a/amtl/am-hashset.h
+++ b/amtl/am-hashset.h
@@ -45,7 +45,7 @@ namespace ke {
 template <typename K,
           typename HashPolicy,
           typename AllocPolicy = SystemAllocatorPolicy>
-class HashSet : public AllocPolicy
+class HashSet : private AllocPolicy
 {
   struct Policy {
     typedef K Payload;
@@ -64,8 +64,8 @@ class HashSet : public AllocPolicy
   typedef HashTable<Policy, AllocPolicy> Internal;
 
  public:
-  HashSet(AllocPolicy ap = AllocPolicy())
-    : table_(ap)
+  explicit HashSet(AllocPolicy ap = AllocPolicy())
+   : table_(ap)
   {
   }
 

--- a/amtl/am-hashtable.h
+++ b/amtl/am-hashtable.h
@@ -128,7 +128,7 @@ namespace detail {
 // Note that the table is not usable until init() has been called.
 //
 template <typename HashPolicy, typename AllocPolicy = SystemAllocatorPolicy>
-class HashTable : public AllocPolicy
+class HashTable : private AllocPolicy
 {
   friend class iterator;
 
@@ -370,7 +370,7 @@ class HashTable : public AllocPolicy
   }
 
  public:
-  HashTable(AllocPolicy ap = AllocPolicy())
+  explicit HashTable(AllocPolicy ap = AllocPolicy())
   : AllocPolicy(ap),
     capacity_(0),
     nelements_(0),

--- a/amtl/am-linkedlist.h
+++ b/amtl/am-linkedlist.h
@@ -47,7 +47,7 @@ namespace ke {
 // exactly one T. If T is very large, LinkedList should be allocated on the
 // heap, to avoid using the stack.
 template <class T, class AllocPolicy = SystemAllocatorPolicy>
-class LinkedList : public AllocPolicy
+class LinkedList : private AllocPolicy
 {
  public:
   friend class iterator;
@@ -60,7 +60,7 @@ class LinkedList : public AllocPolicy
   };
 
 public:
-  LinkedList(AllocPolicy = AllocPolicy())
+  explicit LinkedList(AllocPolicy = AllocPolicy())
    : length_(0)
   {
     head()->prev = head();
@@ -82,6 +82,13 @@ public:
 
   size_t length() const {
     return length_;
+  }
+
+  AllocPolicy& allocPolicy() {
+    return *this;
+  }
+  const AllocPolicy& allocPolicy() const {
+    return *this;
   }
 
   void clear() {
@@ -278,8 +285,8 @@ public:
  private:
   // These are disallowed because they basically violate the failure handling
   // model for AllocPolicies and are also likely to have abysmal performance.
-  LinkedList &operator =(const LinkedList<T> &other) = delete;
-  LinkedList(const LinkedList<T> &other) = delete;
+  LinkedList &operator =(const LinkedList &other) = delete;
+  LinkedList(const LinkedList &other) = delete;
 };
 
 } // namespace ke

--- a/amtl/am-vector.h
+++ b/amtl/am-vector.h
@@ -39,17 +39,19 @@
 namespace ke {
 
 template <typename T, typename AllocPolicy = SystemAllocatorPolicy>
-class Vector : public AllocPolicy
+class Vector final : private AllocPolicy
 {
  public:
-  Vector(AllocPolicy = AllocPolicy())
+  explicit Vector(AllocPolicy = AllocPolicy())
    : data_(nullptr),
      nitems_(0),
      maxsize_(0)
   {
   }
 
-  Vector(Vector &&other) {
+  Vector(Vector &&other)
+   : AllocPolicy(Move(other))
+  {
     data_ = other.data_;
     nitems_ = other.nitems_;
     maxsize_ = other.maxsize_;
@@ -89,6 +91,13 @@ class Vector : public AllocPolicy
       return false;
     new (&data_[at]) T(ke::Forward<U>(item));
     return true;
+  }
+
+  AllocPolicy& allocPolicy() {
+    return *this;
+  }
+  const AllocPolicy& allocPolicy() const {
+    return *this;
   }
 
   // Shift all elements at the given position down, removing the given
@@ -192,8 +201,8 @@ class Vector : public AllocPolicy
  private:
   // These are disallowed because they basically violate the failure handling
   // model for AllocPolicies and are also likely to have abysmal performance.
-  Vector(const Vector<T> &other) = delete;
-  Vector &operator =(const Vector<T> &other) = delete;
+  Vector(const Vector &other) = delete;
+  Vector &operator =(const Vector &other) = delete;
 
  private:
   void destruct_live() {

--- a/tests/test-linkedlist.cpp
+++ b/tests/test-linkedlist.cpp
@@ -254,13 +254,13 @@ class TestLinkedList : public Test
     LinkedList<int, FallibleMalloc> list;
     list.append(5);
     list.append(6);
-    list.setOutOfMemory(true);
+    list.allocPolicy().setOutOfMemory(true);
     if (!check(!list.append(7), "list handled out-of-memory"))
       return false;
-    list.setOutOfMemory(false);
+    list.allocPolicy().setOutOfMemory(false);
     if (!check(list.append(8), "list recovered out-of-memory"))
       return false;
-    if (!check(list.ooms() == 1, "list received 1 oom"))
+    if (!check(list.allocPolicy().ooms() == 1, "list received 1 oom"))
       return false;
     return true;
   }

--- a/tests/test-vector.cpp
+++ b/tests/test-vector.cpp
@@ -255,13 +255,13 @@ class TestVector : public Test
   bool testFallibleMalloc()
   {
     Vector<int, FallibleMalloc> vector;
-    vector.setOutOfMemory(true);
+    vector.allocPolicy().setOutOfMemory(true);
     if (!check(!vector.append(7), "vector handled out-of-memory"))
       return false;
-    vector.setOutOfMemory(false);
+    vector.allocPolicy().setOutOfMemory(false);
     if (!check(vector.append(8), "vector recovered out-of-memory"))
       return false;
-    if (!check(vector.ooms() == 1, "vector received 1 oom"))
+    if (!check(vector.allocPolicy().ooms() == 1, "vector received 1 oom"))
       return false;
     return true;
   }


### PR DESCRIPTION
While playing around I ran into a nasty bug:"

    Vector<int> v1;
    Vector<float> v2(Move(v1));

This does not error in AMTL. Instead it triggers v1 coercing to an AllocPolicy, which matches v2's empty constructor. Super bad.

This patch fixes it by making AllocPolicy inheritance private on all our containers. Since this removes coercion to AllocPolicy, I added explicit accessors in a few places.