### PR TITLE
Add a simple priority queue.

### DIFF
--- a/amtl/am-priority-queue.h
+++ b/amtl/am-priority-queue.h
@@ -1,0 +1,156 @@
+// vim: set sts=8 ts=2 sw=2 tw=99 et:
+//
+// Copyright (C) 2013-2016, David Anderson and AlliedModders LLC
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+//  * Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  * Neither the name of AlliedModders LLC nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef _include_amtl_am_priority_queue_h_
+#define _include_amtl_am_priority_queue_h_
+
+#include <amtl/am-algorithm.h>
+#include <amtl/am-moveable.h>
+#include <amtl/am-vector.h>
+
+namespace ke {
+
+// Basic priority queue implemented using a binary heap on top of Vector. The
+// "IsHigherPriority" callable must take a left and right value of type T, and
+// return whether the left value should be dequeued before the right.
+template <typename T,
+          typename IsHigherPriority = LessThan<T>,
+          typename AllocPolicy = SystemAllocatorPolicy>
+class PriorityQueue final
+{
+ public:
+  explicit PriorityQueue(IsHigherPriority hp = IsHigherPriority(),
+                         AllocPolicy ap = AllocPolicy())
+   : impl_(ap),
+     is_higher_priority_(hp)
+  {}
+
+  PriorityQueue(PriorityQueue&& other)
+   : impl_(Move(other.impl_)),
+     is_higher_priority_(Move(other.is_higher_priority_))
+  {
+  }
+
+  template <typename U>
+  bool add(U&& item) {
+    if (!impl_.append(ke::Forward<U>(item)))
+      return false;
+    if (impl_.length() > 1)
+      propagateUp(impl_.length() - 1);
+    return true;
+  }
+
+  bool empty() const {
+    return impl_.empty();
+  }
+
+  const T& peek() const {
+    assert(!empty());
+    return impl_[0];
+  }
+
+  T popCopy() {
+    assert(!empty());
+
+    if (impl_.length() == 1)
+      return impl_.popCopy();
+
+    T top = Move(impl_[0]);
+    impl_[0] = Move(impl_.back());
+    impl_.pop();
+    propagateDown(0);
+    return top;
+  }
+
+ private:
+  void propagateUp(size_t at) {
+    size_t cursor = at;
+    while (cursor != 0) {
+      size_t parent = parentOf(cursor);
+      if (!is_higher_priority_(impl_[cursor], impl_[parent]))
+        break;
+      ke::Swap(impl_[parent], impl_[cursor]);
+      cursor = parent;
+    }
+  }
+
+  void propagateDown(size_t at) {
+    size_t cursor = at;
+    while (hasLeftChild(cursor)) {
+      // Pick the child with the highest priority.
+      size_t bestChild = leftChildOf(cursor);
+      if (hasRightChild(cursor)) {
+        size_t rightIndex = rightChildOf(cursor);
+        if (is_higher_priority_(impl_[rightIndex], impl_[bestChild]))
+          bestChild = rightIndex;
+      }
+
+      // If the highest priority child is not higher priority than the cursor,
+      // then we are finished.
+      if (!is_higher_priority_(impl_[bestChild], impl_[cursor]))
+        break;
+
+      // Otherwise, swap and move on.
+      ke::Swap(impl_[bestChild], impl_[cursor]);
+      cursor = bestChild;
+    }
+  }
+
+  static constexpr size_t parentOf(size_t at) {
+#if __cplusplus >= 201402L
+    assert(at > 0);
+#endif
+    return (at - 1) / 2;
+  }
+  static constexpr size_t leftChildOf(size_t at) {
+    return (at * 2) + 1;
+  }
+  static constexpr size_t rightChildOf(size_t at) {
+    return (at * 2) + 2;
+  }
+
+  bool hasLeftChild(size_t at) const {
+    return leftChildOf(at) < impl_.length();
+  }
+  bool hasRightChild(size_t at) const {
+    return rightChildOf(at) < impl_.length();
+  }
+
+ private:
+  PriorityQueue(const PriorityQueue& other) = delete;
+  void operator =(const PriorityQueue& other) = delete;
+
+ private:
+  Vector<T, AllocPolicy> impl_;
+  IsHigherPriority is_higher_priority_;
+};
+
+} // namespace ke
+
+#endif // _include_amtl_am_priority_queue_h_

--- a/tests/AMBuild.tests
+++ b/tests/AMBuild.tests
@@ -43,6 +43,7 @@ binary.sources += [
   'test-threadutils.cpp',
   'test-deque.cpp',
   'test-system.cpp',
+  'test-priority-queue.cpp',
 ]
 
 builder.Add(binary)

--- a/tests/test-priority-queue.cpp
+++ b/tests/test-priority-queue.cpp
@@ -1,6 +1,6 @@
 // vim: set sts=8 ts=2 sw=2 tw=99 et:
 //
-// Copyright (C) 2013-2014, David Anderson and AlliedModders LLC
+// Copyright (C) 2013, David Anderson and AlliedModders LLC
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -26,49 +26,54 @@
 // CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-#ifndef _include_amtl_algorithm_h_
-#define _include_amtl_algorithm_h_
 
-#include <amtl/am-moveable.h>
+#include <amtl/am-priority-queue.h>
+#include <assert.h>
+#include "runner.h"
 
-namespace ke {
+using namespace ke;
 
-template <typename T> static inline T
-Min(const T &t1, const T &t2)
+class TestPriorityQueue : public Test
 {
-    return t1 < t2 ? t1 : t2;
-}
-
-template <typename T> static inline T
-Max(const T &t1, const T &t2)
-{
-    return t1 > t2 ? t1 : t2;
-}
-
-template <typename T> static inline void
-Swap(T &left, T &right)
-{
-  T tmp(Move(left));
-  left = Move(right);
-  right = Move(tmp);
-}
-
-template <typename T>
-struct LessThan
-{
-  constexpr bool operator ()(const T& left, const T& right) const {
-    return left < right;
+ public:
+  TestPriorityQueue()
+   : Test("PriorityQueue")
+  {
   }
-};
 
-template <typename T>
-struct GreaterThan
-{
-  constexpr bool operator ()(const T& left, const T& right) const {
-    return left > right;
+  bool testBasic()
+  {
+    PriorityQueue<int> pq;
+    pq.add(16);
+    pq.add(16);
+    pq.add(16);
+    pq.add(9);
+    pq.add(77);
+    pq.add(3);
+
+    if (!check(pq.popCopy() == 3, "should pop 3"))
+      return false;
+    if (!check(pq.popCopy() == 9, "should pop 9"))
+      return false;
+    if (!check(pq.popCopy() == 16, "should pop 16"))
+      return false;
+    if (!check(pq.popCopy() == 16, "should pop 16"))
+      return false;
+    if (!check(pq.popCopy() == 16, "should pop 16"))
+      return false;
+    if (!check(pq.popCopy() == 77, "should pop 77"))
+      return false;
+    if (!check(pq.empty(), "should be empty"))
+      return false;
+
+    return true;
   }
-};
 
-} // namespace ke
+  bool Run() override
+  {
+    if (!testBasic())
+      return false;
+    return true;
+  }
+} sTestPriorityQueue;
 
-#endif // _include_amtl_algorithm_h_


### PR DESCRIPTION
This is a super simple wrapper around Vector, implementing a priority queue using a binary heap. I think we intended to have something like this for SM or AMXX tasks ages ago, but never got around to it.