### PR TITLE
Fix MSVC2013 support.

### DIFF
--- a/amtl/am-algorithm.h
+++ b/amtl/am-algorithm.h
@@ -29,6 +29,7 @@
 #ifndef _include_amtl_algorithm_h_
 #define _include_amtl_algorithm_h_
 
+#include <amtl/am-cxx.h>
 #include <amtl/am-moveable.h>
 
 namespace ke {
@@ -56,7 +57,7 @@ Swap(T &left, T &right)
 template <typename T>
 struct LessThan
 {
-  constexpr bool operator ()(const T& left, const T& right) const {
+  KE_CONSTEXPR bool operator ()(const T& left, const T& right) const {
     return left < right;
   }
 };
@@ -64,7 +65,7 @@ struct LessThan
 template <typename T>
 struct GreaterThan
 {
-  constexpr bool operator ()(const T& left, const T& right) const {
+  KE_CONSTEXPR bool operator ()(const T& left, const T& right) const {
     return left > right;
   }
 };

--- a/amtl/am-cxx.h
+++ b/amtl/am-cxx.h
@@ -84,6 +84,9 @@
 # if KE_CLANG_AT_LEAST(3, 1)
 #  define KE_CXX_HAS_CONSTEXPR
 # endif
+# if KE_CLANG_AT_LEAST(3, 4)
+#  define KE_CXX_HAS_GENERIC_LAMBDA_CAPTURES
+# endif
 
 #elif defined(__GNUC__)
 # define KE_GCC_AT_LEAST(x, y) ((__GNUC__ > (x)) || (__GNUC__ == x && __GNUC_MINOR__ >= y))
@@ -112,6 +115,9 @@
 # if KE_GCC_AT_LEAST(4, 7)
 #  define KE_CXX_HAS_OVERRIDE
 # endif
+# if KE_GCC_AT_LEAST(4, 9)
+#  define KE_CXX_HAS_GENERIC_LAMBDA_CAPTURES
+# endif
 
 #elif defined(_MSC_VER)
 # if _MSC_VER >= 1600
@@ -136,6 +142,7 @@
 # if _MSC_VER >= 1900
 #  define KE_CXX_HAS_CONSTEXPR
 #  define KE_CXX_HAS_NOEXCEPT
+#  define KE_CXX_HAS_GENERIC_LAMBDA_CAPTURES
 # endif
 #else
 # error Unrecognized compiler.

--- a/amtl/am-priority-queue.h
+++ b/amtl/am-priority-queue.h
@@ -31,6 +31,7 @@
 #define _include_amtl_am_priority_queue_h_
 
 #include <amtl/am-algorithm.h>
+#include <amtl/am-cxx.h>
 #include <amtl/am-moveable.h>
 #include <amtl/am-vector.h>
 
@@ -122,16 +123,16 @@ class PriorityQueue final
     }
   }
 
-  static constexpr size_t parentOf(size_t at) {
+  static KE_CONSTEXPR size_t parentOf(size_t at) {
 #if __cplusplus >= 201402L
     assert(at > 0);
 #endif
     return (at - 1) / 2;
   }
-  static constexpr size_t leftChildOf(size_t at) {
+  static KE_CONSTEXPR size_t leftChildOf(size_t at) {
     return (at * 2) + 1;
   }
-  static constexpr size_t rightChildOf(size_t at) {
+  static KE_CONSTEXPR size_t rightChildOf(size_t at) {
     return (at * 2) + 2;
   }
 

--- a/tests/test-callable.cpp
+++ b/tests/test-callable.cpp
@@ -252,6 +252,7 @@ class TestCallable : public Test
   }
 
   bool testMoveUncopyable() {
+#if defined(KE_CXX_HAS_GENERIC_LAMBDA_CAPTURES)
     Vector<int> v;
 
     auto lambda = [v = Move(v)]() -> size_t {
@@ -263,6 +264,7 @@ class TestCallable : public Test
 
     if (!check(f() == 0, "f() should have returned 0"))
       return false;
+#endif
 
     return true;
   }


### PR DESCRIPTION
Until all our AppVeyors are updated, we should keep MSVC2013 support. Use of generic lambda captures and constexpr is now compile-time tested.