### PR TITLE
Fix am-hashtable lookupForAdd not scanning past removed entries from the probulator (bug 6527).

### DIFF
--- a/amtl/am-hashtable.h
+++ b/amtl/am-hashtable.h
@@ -331,7 +331,7 @@ class HashTable : private AllocPolicy
       e = &table_[probulator.next()];
     }
 
-	if (!e->isLive() && firstRemoved)
+    if (!e->isLive() && firstRemoved)
       e = firstRemoved;
 
     return Insert(e, hash);

--- a/amtl/am-hashtable.h
+++ b/amtl/am-hashtable.h
@@ -320,9 +320,9 @@ class HashTable : private AllocPolicy
 
     Entry *e = &table_[probulator.entry()];
     for (;;) {
-      if (!e->isLive())
+      if (e->isFree())
         break;
-      if (e->sameHash(hash) && HashPolicy::matches(key, e->payload()))
+      if (!e->removed() && e->sameHash(hash) && HashPolicy::matches(key, e->payload()))
         break;
       e = &table_[probulator.next()];
     }

--- a/amtl/am-hashtable.h
+++ b/amtl/am-hashtable.h
@@ -329,9 +329,8 @@ class HashTable : private AllocPolicy
       if (e->removed()) {
         if (!firstRemoved)
          firstRemoved = e;
-      }
-      else if (e->sameHash(hash) && HashPolicy::matches(key, e->payload()))
-        break;
+      } else if (e->sameHash(hash) && HashPolicy::matches(key, e->payload()))
+          break;
       e = &table_[probulator.next()];
     }
 

--- a/amtl/am-hashtable.h
+++ b/amtl/am-hashtable.h
@@ -321,18 +321,18 @@ class HashTable : private AllocPolicy
     Entry *e = &table_[probulator.entry()];
     Entry *firstRemoved = nullptr;
     for (;;) {
-      if (e->isFree()) {
-        if (firstRemoved)
-         e = firstRemoved;
+      if (e->isFree())
         break;
-      }
       if (e->removed()) {
         if (!firstRemoved)
-         firstRemoved = e;
+          firstRemoved = e;
       } else if (e->sameHash(hash) && HashPolicy::matches(key, e->payload()))
           break;
       e = &table_[probulator.next()];
     }
+
+	if (!e->isLive() && firstRemoved)
+      e = firstRemoved;
 
     return Insert(e, hash);
   }

--- a/amtl/am-hashtable.h
+++ b/amtl/am-hashtable.h
@@ -319,10 +319,18 @@ class HashTable : private AllocPolicy
     Probulator probulator(hash, capacity_);
 
     Entry *e = &table_[probulator.entry()];
+	Entry *firstRemoved = nullptr;
     for (;;) {
-      if (e->isFree())
+      if (e->isFree()) {
+        if (firstRemoved)
+         e = firstRemoved;
         break;
-      if (!e->removed() && e->sameHash(hash) && HashPolicy::matches(key, e->payload()))
+      }
+      if (e->removed()) {
+        if (!firstRemoved)
+         firstRemoved = e;
+      }
+      else if (e->sameHash(hash) && HashPolicy::matches(key, e->payload()))
         break;
       e = &table_[probulator.next()];
     }

--- a/amtl/am-hashtable.h
+++ b/amtl/am-hashtable.h
@@ -319,7 +319,7 @@ class HashTable : private AllocPolicy
     Probulator probulator(hash, capacity_);
 
     Entry *e = &table_[probulator.entry()];
-	Entry *firstRemoved = nullptr;
+    Entry *firstRemoved = nullptr;
     for (;;) {
       if (e->isFree()) {
         if (firstRemoved)


### PR DESCRIPTION
This is a reworked patch from https://bugs.alliedmods.net/show_bug.cgi?id=6527 .

At the moment HashTable::lookupForAdd will break on it's search if a single entry has been removed, resulting in multiple unique entries being present in SourceMod's StringHashMap. HashTable::lookup instead checks if the entries are free.

This has multiple drawbacks that I'm assuming this was supposed to account for, such as effectively defragging the hashtable when a new entry is inserted. The real fix is to do a full lookup, and if the hash is not present; insert on the first "removed" entry. If we want to do this full scan or not to ensure there are no collisions is unknown to me.