### PR TITLE
Modernize AutoPtr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ All classes and functions reside in a "ke" namespace, and all macros are prefixe
 ### Platform Utilities (am-utilities.h)
 
 This provides some common helper functions pretty much lumped together:
-* AutoPtr<T>, RAII for calling delete on a pointer.
-* AutoArray<T>, RAII for calling delete[] on a pointer.
+* AutoPtr<T> and AutoPtr<T[]>, RAII objects for calling delete or delete[] on a pointer.
 * Detectors for add or multiply overflow, useful for computing allocation sizes.
 * Fast Log2/Floor2 functions (also known as bitscan or count zeroes).
 * Integer alignment (useful for allocators or code generators).

--- a/amtl/am-autoptr.h
+++ b/amtl/am-autoptr.h
@@ -106,62 +106,70 @@ class AutoPtr
 // Wrapper that automatically deletes its contents. The pointer can be taken
 // to avoid destruction.
 template <typename T>
-class AutoArray
+class AutoPtr<T[]>
 {
  public:
-  AutoArray()
+  AutoPtr()
    : t_(nullptr)
   {
   }
-  AutoArray(AutoArray&& other)
+  AutoPtr(AutoPtr&& other)
     : t_(other.t_)
   {
     other.t_ = nullptr;
   }
-  explicit AutoArray(T *t)
+  explicit AutoPtr(T *t)
    : t_(t)
   {
   }
-  ~AutoArray() {
-      delete [] t_;
+  ~AutoPtr() {
+    delete [] t_;
   }
   T *take() {
-      return ReturnAndVoid(t_);
+    return ReturnAndVoid(t_);
   }
   T *forget() {
-      return ReturnAndVoid(t_);
-  }
-  T **address() {
-    return &t_;
+    return ReturnAndVoid(t_);
   }
   T &operator *() const {
-      return t_;
+    return t_;
   }
   operator T *() const {
-      return t_;
+    return t_;
   }
   bool operator !() const {
-      return !t_;
+    return !t_;
   }
+  explicit operator bool() const {
+    return t_ != nullptr;
+  }
+
+  void assign(T* ptr) {
+    delete[] t_;
+    t_ = ptr;
+  }
+
+  T& operator[](size_t index) {
+    return t_[index];
+  }
+
   T* get() const {
     return t_;
   }
 
-  AutoArray& operator =(T *t) {
-      delete [] t_;
-      t_ = t;
-      return *this;
+  AutoPtr& operator =(decltype(nullptr)) {
+    assign(nullptr);
+    return *this;
   }
-  AutoArray& operator =(AutoArray&& other) {
-      delete[] t_;
-      t_ = other.t_;
-      other.t_ = nullptr;
-      return *this;
+  AutoPtr& operator =(AutoPtr&& other) {
+    assign(other.t_);
+    other.t_ = nullptr;
+    return *this;
   }
 
  private:
-  AutoArray(const AutoArray& other) = delete;
-  AutoArray& operator =(const AutoArray& other) = delete;
+  AutoPtr(const AutoPtr& other) = delete;
+  AutoPtr& operator =(const AutoPtr& other) = delete;
 
  private:
   T *t_;

--- a/amtl/am-string.h
+++ b/amtl/am-string.h
@@ -98,7 +98,7 @@ class AString
     return *this;
   }
   AString &operator =(AString &&other) {
-    chars_ = other.chars_.take();
+    chars_ = Move(other.chars_);
     length_ = other.length_;
     other.length_ = 0;
     return *this;
@@ -134,14 +134,14 @@ class AString
   static const size_t kInvalidLength = (size_t)-1;
 
   void set(const char *str, size_t length) {
-    chars_ = new char[length + 1];
+    chars_.assign(new char[length + 1]);
     length_ = length;
     memcpy(chars_, str, length);
     chars_[length] = '\0';
   }
 
  private:
-  AutoArray<char> chars_;
+  AutoPtr<char[]> chars_;
   size_t length_;
 };
 

--- a/amtl/am-type-traits.h
+++ b/amtl/am-type-traits.h
@@ -148,6 +148,16 @@ struct decay {
   >::type type;
 };
 
+// Remove one extent from an array type.
+template <typename T>
+struct remove_extent { typedef T type; };
+
+template <typename T>
+struct remove_extent<T[]> { typedef T type; };
+
+template <typename T, size_t N>
+struct remove_extent<T[N]> { typedef T type; };
+
 } // namespace ke
 
 #endif // _include_amtl_type_traits_h_

--- a/tests/AMBuild.tests
+++ b/tests/AMBuild.tests
@@ -45,6 +45,7 @@ binary.sources += [
   'test-system.cpp',
   'test-priority-queue.cpp',
   'test-string.cpp',
+  'test-autoptr.cpp',
 ]
 
 builder.Add(binary)

--- a/tests/test-autoptr.cpp
+++ b/tests/test-autoptr.cpp
@@ -1,0 +1,88 @@
+// vim: set sts=8 ts=2 sw=2 tw=99 et:
+//
+// Copyright (C) 2013, David Anderson and AlliedModders LLC
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+//  * Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  * Neither the name of AlliedModders LLC nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <am-autoptr.h>
+#include "runner.h"
+
+using namespace ke;
+
+static size_t sBlahCtors = 0;
+static size_t sBlahDtors = 0;
+struct Blah {
+  Blah() {
+    sBlahCtors++;
+  }
+  ~Blah() {
+    sBlahDtors++;
+  }
+};
+
+class TestAutoPtr : public Test
+{
+ public:
+  TestAutoPtr()
+   : Test("AutoPtr")
+  {
+  }
+
+  bool Run() override
+  {
+    if (!testSingle())
+      return false;
+    return true;
+  };
+
+ private:
+  bool testSingle() {
+    AutoPtr<int> five = MakeUnique<int>(5);
+    if (!check(*five.get() == 5, "pointer should contain 5"))
+      return false;
+
+    {
+      AutoPtr<Blah> blah = MakeUnique<Blah>();
+      if (!check(sBlahCtors == 1, "called Blah::Blah"))
+        return false;
+    }
+    if (!check(sBlahDtors == 1, "called Blah::~Blah"))
+      return false;
+
+    sBlahCtors = 0;
+    sBlahDtors = 0;
+    {
+      AutoPtr<Blah[]> blah = MakeUnique<Blah[]>(20);
+      if (!check(sBlahCtors == 20, "called Blah::Blah 20 times"))
+        return false;
+    }
+    if (!check(sBlahDtors == 20, "called Blah::~Blah 20 times"))
+      return false;
+
+    return true;
+  }
+
+} sTestAutoPtr;


### PR DESCRIPTION
AutoPtr is roughly unique_ptr from C++11. These patches bring it more in-line with C++14.

1. `AutoArray` is removed. `AutoArray<T>` should now be written as `AutoArray<T[]>`.
1. `AutoPtr<T[]>` no longer has raw pointer assignment through `operator =`.
1. An overload for `operator []` is provided again. It was removed in PR #12, but we no longer support the problematic compiler there (GCC 4.5).
1. `MakeUnique` is provided as a straight copy of C++14's `make_unique`.

The standard library also has a "deleter" feature that is somewhat akin to PR #8. This looks like it introduces a lot of complexity and AM hasn't needed it yet, so I left that out for now.