### PR TITLE
Remove AutoPtr implicit cast-to-T and assign-from-T*.

### DIFF
--- a/amtl/am-autoptr.h
+++ b/amtl/am-autoptr.h
@@ -75,14 +75,6 @@ class AutoPtr
  T *operator ->() const {
      return t_;
  }
- operator T *() const {
-     return t_;
- }
- T *operator =(T *t) {
-     delete t_;
-     t_ = t;
-     return t_;
- }
  T **address() {
    return &t_;
  }
@@ -126,20 +118,14 @@ class AutoPtr<T[]>
   ~AutoPtr() {
     delete [] t_;
   }
+  T *get() {
+    return t_;
+  }
   T *take() {
     return ReturnAndVoid(t_);
   }
   T *forget() {
     return ReturnAndVoid(t_);
-  }
-  T &operator *() const {
-    return t_;
-  }
-  operator T *() const {
-    return t_;
-  }
-  bool operator !() const {
-    return !t_;
   }
   explicit operator bool() const {
     return t_ != nullptr;

--- a/amtl/am-string.h
+++ b/amtl/am-string.h
@@ -68,7 +68,7 @@ class AString
   }
   AString(const AString &other) {
     if (other.length_)
-      set(other.chars_, other.length_);
+      set(other.chars_.get(), other.length_);
     else
       length_ = 0;
   }
@@ -90,7 +90,7 @@ class AString
   }
   AString &operator =(const AString &other) {
     if (other.length_) {
-      set(other.chars_, other.length_);
+      set(other.chars_.get(), other.length_);
     } else {
       chars_ = nullptr;
       length_ = 0;
@@ -127,7 +127,7 @@ class AString
   const char *chars() const {
     if (!chars_)
       return "";
-    return chars_;
+    return chars_.get();
   }
 
  private:
@@ -136,7 +136,7 @@ class AString
   void set(const char *str, size_t length) {
     chars_.assign(new char[length + 1]);
     length_ = length;
-    memcpy(chars_, str, length);
+    memcpy(chars_.get(), str, length);
     chars_[length] = '\0';
   }
 


### PR DESCRIPTION
This removes two kind of unsafe features of AutoPtr. First, cast-to-T makes `operator *` confusing. It's easy to do the wrong dereference. Second, assign-from-T* makes it too easy to implicitly adopt pointers that maybe shouldn't be adopted.

We'll see how this plays out with AM code - if things become too gross I will back this out.