### PR TITLE
Move AutoPtr changes to new UniquePtr class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ All classes and functions reside in a "ke" namespace, and all macros are prefixe
 
 This provides some common helper functions pretty much lumped together:
 * AutoPtr<T> and AutoPtr<T[]>, RAII objects for calling delete or delete[] on a pointer.
+* UniquePtr<T> and UniquePtr<T[]>, more restrictive version of AutoPtr, similar to C++11 unique\_ptr.
 * Detectors for add or multiply overflow, useful for computing allocation sizes.
 * Fast Log2/Floor2 functions (also known as bitscan or count zeroes).
 * Integer alignment (useful for allocators or code generators).
@@ -249,6 +250,16 @@ called AString (short for ASCII String).
 
 FixedArray&lt;T, AP&gt; is a stripped-down version of Vector that is constructed with a fixed
 length. The length is passed via the constructor; a compile-time length variant is planned.
+
+### AutoPtr and UniquePtr (am-autoptr.h and am-uniqueptr.h)
+
+Both classes are similar to C++11's `unique_ptr`. The only difference is that UniquePtr is
+more restrictive: it does not support assignment from `T` or implicit cast-to-`T`, making it
+harder to dereference incorrectly or accidentally double-delete.
+
+Note that AutoPtr is not similar to the C++03 `auto_ptr` class. It is simply a slightly more
+permissive UniquePtr. It is intended for code that benefits from automatic deletion, but
+not from the verbosity introduced by some of UniquePtr's safety features.
 
 # Replacing SourceHook Includes
 

--- a/amtl/am-autoptr.h
+++ b/amtl/am-autoptr.h
@@ -44,54 +44,49 @@ template <typename T>
 class AutoPtr
 {
  public:
-  AutoPtr()
-    : t_(nullptr)
-  {
-  }
-  explicit AutoPtr(T *t)
-    : t_(t)
-  {
-  }
-  AutoPtr(AutoPtr &&other)
-  {
-      t_ = other.t_;
-      other.t_ = nullptr;
-  }
-  ~AutoPtr() {
-      delete t_;
-  }
-  T *get() const {
-    return t_;
-  }
-  T *take() {
-      return ReturnAndVoid(t_);
-  }
-  T *forget() {
-      return ReturnAndVoid(t_);
-  }
-  T *operator *() const {
-      return t_;
-  }
-  T *operator ->() const {
-      return t_;
-  }
-  T **address() {
-    return &t_;
-  }
-  T *operator =(AutoPtr &&other) {
-    delete t_;
-    t_ = other.t_;
-    other.t_ = nullptr;
-    return t_;
-  }
-  AutoPtr& operator =(decltype(nullptr)) {
-    delete t_;
-    t_ = nullptr;
-    return *this;
-  }
-  explicit operator bool() const {
-    return t_ != nullptr;
-  }
+ AutoPtr()
+   : t_(nullptr)
+ {
+ }
+ explicit AutoPtr(T *t)
+   : t_(t)
+ {
+ }
+ AutoPtr(AutoPtr &&other)
+ {
+     t_ = other.t_;
+     other.t_ = nullptr;
+ }
+ ~AutoPtr() {
+     delete t_;
+ }
+ T *get() const {
+   return t_;
+ }
+ T *take() {
+     return ReturnAndVoid(t_);
+ }
+ T *forget() {
+     return ReturnAndVoid(t_);
+ }
+ T *operator *() const {
+     return t_;
+ }
+ T *operator ->() const {
+     return t_;
+ }
+ T **address() {
+   return &t_;
+ }
+ T *operator =(AutoPtr &&other) {
+     delete t_;
+     t_ = other.t_;
+     other.t_ = nullptr;
+     return t_;
+ }
+ bool operator !() const {
+     return !t_;
+ }
 
  private:
   AutoPtr(const AutoPtr &other) = delete;

--- a/amtl/am-autoptr.h
+++ b/amtl/am-autoptr.h
@@ -45,39 +45,35 @@ class AutoPtr
 {
  public:
   AutoPtr()
-   : t_(nullptr)
+    : t_(nullptr)
   {
   }
   explicit AutoPtr(T *t)
-   : t_(t)
+    : t_(t)
   {
   }
   AutoPtr(AutoPtr &&other)
   {
-    t_ = other.t_;
-    other.t_ = nullptr;
+      t_ = other.t_;
+      other.t_ = nullptr;
   }
   ~AutoPtr() {
-    delete t_;
+      delete t_;
   }
   T *get() const {
     return t_;
   }
   T *take() {
-    return ReturnAndVoid(t_);
+      return ReturnAndVoid(t_);
   }
   T *forget() {
-    return ReturnAndVoid(t_);
-  }
-  void assign(T* ptr) {
-    delete t_;
-    t_ = ptr;
+      return ReturnAndVoid(t_);
   }
   T *operator *() const {
-    return t_;
+      return t_;
   }
   T *operator ->() const {
-    return t_;
+      return t_;
   }
   T **address() {
     return &t_;

--- a/tests/AMBuild.tests
+++ b/tests/AMBuild.tests
@@ -46,6 +46,7 @@ binary.sources += [
   'test-priority-queue.cpp',
   'test-string.cpp',
   'test-autoptr.cpp',
+  'test-uniqueptr.cpp',
 ]
 
 builder.Add(binary)

--- a/tests/test-autoptr.cpp
+++ b/tests/test-autoptr.cpp
@@ -64,10 +64,6 @@ class TestAutoPtr : public Test
     if (!check(*five.get() == 5, "pointer should contain 5"))
       return false;
 
-    five = nullptr;
-    if (!check(!five, "pointer should be null"))
-      return false;
-
     {
       AutoPtr<Blah> blah = MakeUnique<Blah>();
       if (!check(sBlahCtors == 1, "called Blah::Blah"))

--- a/tests/test-uniqueptr.cpp
+++ b/tests/test-uniqueptr.cpp
@@ -27,27 +27,27 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <am-autoptr.h>
+#include <am-uniqueptr.h>
 #include "runner.h"
 
 using namespace ke;
 
-static size_t sBlahCtors = 0;
-static size_t sBlahDtors = 0;
-struct Blah {
-  Blah() {
-    sBlahCtors++;
+static size_t sBrahCtors = 0;
+static size_t sBrahDtors = 0;
+struct Brah {
+  Brah() {
+    sBrahCtors++;
   }
-  ~Blah() {
-    sBlahDtors++;
+  ~Brah() {
+    sBrahDtors++;
   }
 };
 
-class TestAutoPtr : public Test
+class TestUniquePtr : public Test
 {
  public:
-  TestAutoPtr()
-   : Test("AutoPtr")
+  TestUniquePtr()
+   : Test("UniquePtr")
   {
   }
 
@@ -60,29 +60,33 @@ class TestAutoPtr : public Test
 
  private:
   bool testSingle() {
-    AutoPtr<int> five(new int(5));
+    UniquePtr<int> five = MakeUnique<int>(5);
     if (!check(*five.get() == 5, "pointer should contain 5"))
       return false;
 
-    {
-      AutoPtr<Blah> blah(new Blah());
-      if (!check(sBlahCtors == 1, "called Blah::Blah"))
-        return false;
-    }
-    if (!check(sBlahDtors == 1, "called Blah::~Blah"))
+    five = nullptr;
+    if (!check(!five, "pointer should be null"))
       return false;
 
-    sBlahCtors = 0;
-    sBlahDtors = 0;
     {
-      AutoPtr<Blah[]> blah(new Blah[20]);
-      if (!check(sBlahCtors == 20, "called Blah::Blah 20 times"))
+      UniquePtr<Brah> blah = MakeUnique<Brah>();
+      if (!check(sBrahCtors == 1, "called Brah::Brah"))
         return false;
     }
-    if (!check(sBlahDtors == 20, "called Blah::~Blah 20 times"))
+    if (!check(sBrahDtors == 1, "called Brah::~Brah"))
+      return false;
+
+    sBrahCtors = 0;
+    sBrahDtors = 0;
+    {
+      UniquePtr<Brah[]> blah = MakeUnique<Brah[]>(20);
+      if (!check(sBrahCtors == 20, "called Brah::Brah 20 times"))
+        return false;
+    }
+    if (!check(sBrahDtors == 20, "called Brah::~Brah 20 times"))
       return false;
 
     return true;
   }
 
-} sTestAutoPtr;
+} sTestUniquePtr;


### PR DESCRIPTION
The AutoPtr changes were too aggressive for AM code, SourceMod started to look ugly. Instead, I reverted AutoPtr and copied the new version to UniquePtr.