### PR TITLE
Reworked am-function.h

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,15 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise-3.8
     packages:
       - lib32stdc++6
       - lib32z1-dev
       - libc6-dev-i386
       - g++-multilib
-      - g++-4.8
-      - g++-4.7
+      - g++-5
+      - g++-6
+      - clang-3.8
 language: cpp
 sudo: false
 compiler:
@@ -18,7 +20,7 @@ before_script:
 script:
   - PATH="~/.local/bin:$PATH"
   - mkdir build-clang-opt && cd build-clang-opt
-  - python ../configure.py --enable-optimize
+  - CC="clang-3.8" CXX="clang++-3.8" python ../configure.py --enable-optimize
   - ambuild
   - ./tests/testrunner/testrunner
   - cd ..
@@ -29,26 +31,26 @@ script:
   - ./tests/testrunner/testrunner
   - cd ..
 
-  - mkdir build-gcc47-opt && cd build-clang-opt
-  - CC="gcc-4.7" CXX="g++-4.7" python ../configure.py --enable-optimize
+  - mkdir build-gcc5-opt && cd build-gcc5-opt
+  - CC="gcc-5" CXX="g++-5" python ../configure.py --enable-optimize
   - ambuild
   - ./tests/testrunner/testrunner
   - cd ..
 
-  - mkdir build-gcc47-debug && cd build-clang-debug
-  - CC="gcc-4.7" CXX="g++-4.7" python ../configure.py --enable-debug
+  - mkdir build-gcc5-debug && cd build-gcc5-debug
+  - CC="gcc-5" CXX="g++-5" python ../configure.py --enable-debug
   - ambuild
   - ./tests/testrunner/testrunner
   - cd ..
 
-  - mkdir build-gcc48-opt && cd build-clang-opt
-  - CC="gcc-4.8" CXX="g++-4.8" python ../configure.py --enable-optimize
+  - mkdir build-gcc6-opt && cd build-gcc6-opt
+  - CC="gcc-6" CXX="g++-6" python ../configure.py --enable-optimize
   - ambuild
   - ./tests/testrunner/testrunner
   - cd ..
 
-  - mkdir build-gcc48-debug && cd build-clang-debug
-  - CC="gcc-4.8" CXX="g++-4.8" python ../configure.py --enable-debug
+  - mkdir build-gcc6-debug && cd build-gcc6-debug
+  - CC="gcc-6" CXX="g++-6" python ../configure.py --enable-debug
   - ambuild
   - ./tests/testrunner/testrunner
   - cd ..

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -10,12 +10,12 @@ class KEConfig(object):
     cfg = builder.DetectCompilers()
     cxx = cfg.cxx
 
-    if cfg.version < 'clang-3.0' or cfg.version < 'apple-clang-3.0':
-      raise Exception('AMTL requires clang 3.0 or higher.')
-    if cfg.version < 'gcc-4.5':
-      raise Exception('AMTL requires GCC 4.5 or higher.')
-    if cfg.version < 'msvc-1600':
-      raise Exception('AMTL requires Visual Studio 2010 (CL 16.00) or higher.')
+    if cfg.version < 'clang-3.3' or cfg.version < 'apple-clang-3.3':
+      raise Exception('AMTL requires clang 3.3 or higher.')
+    if cfg.version < 'gcc-4.7':
+      raise Exception('AMTL requires GCC 4.7 or higher.')
+    if cfg.version < 'msvc-1800':
+      raise Exception('AMTL requires Visual Studio 2013 (CL 18.00) or higher.')
 
     if cxx.like('gcc'):
       if builder.target_platform != 'windows':
@@ -24,15 +24,11 @@ class KEConfig(object):
             cfg.cxxflags += ['-std=c++14']
           elif cxx.version >= '4.7':
             cfg.cxxflags += ['-std=c++11']
-          elif cxx.version >= '4.3':
-            cfg.cxxflags += ['-std=c++0x']
         else:
           if cxx.version >= '3.5':
             cfg.cxxflags += ['-std=c++14']
           elif cxx.version >= '3.3':
             cfg.cxxflags += ['-std=c++1y']
-          else:
-            cfg.cxxflags += ['-std=c++11']
 
         cfg.defines += [
           'stricmp=strcasecmp',
@@ -60,6 +56,8 @@ class KEConfig(object):
       if have_clang or (have_gcc and cxx.majorVersion >= 4):
         cfg.cflags += ['-fvisibility=hidden']
         cfg.cxxflags += ['-fvisibility-inlines-hidden']
+      if have_clang:
+        cfg.cflags += ['-Wno-implicit-exception-spec-mismatch']
 
       cfg.cxxflags += [
         '-fno-exceptions',

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -12,7 +12,7 @@ class KEConfig(object):
 
     if cfg.version < 'clang-3.3' or cfg.version < 'apple-clang-3.3':
       raise Exception('AMTL requires clang 3.3 or higher.')
-    if cfg.version < 'gcc-4.7':
+    if cfg.version < 'gcc-5.4':
       raise Exception('AMTL requires GCC 4.7 or higher.')
     if cfg.version < 'msvc-1800':
       raise Exception('AMTL requires Visual Studio 2013 (CL 18.00) or higher.')
@@ -20,10 +20,7 @@ class KEConfig(object):
     if cxx.like('gcc'):
       if builder.target_platform != 'windows':
         if cxx.name == 'gcc':
-          if cxx.version >= '4.9':
-            cfg.cxxflags += ['-std=c++14']
-          elif cxx.version >= '4.7':
-            cfg.cxxflags += ['-std=c++11']
+          cfg.cxxflags += ['-std=c++14']
         else:
           if cxx.version >= '3.5':
             cfg.cxxflags += ['-std=c++14']

--- a/amtl/am-cxx.h
+++ b/amtl/am-cxx.h
@@ -84,6 +84,9 @@
 # if KE_CLANG_AT_LEAST(3, 1)
 #  define KE_CXX_HAS_CONSTEXPR
 # endif
+# if KE_CLANG_AT_LEAST(3, 3)
+#  define KE_CXX_HAS_ALIAS_TEMPLATES
+# endif
 # if KE_CLANG_AT_LEAST(3, 4)
 #  define KE_CXX_HAS_GENERIC_LAMBDA_CAPTURES
 # endif
@@ -118,6 +121,9 @@
 # if KE_GCC_AT_LEAST(4, 9)
 #  define KE_CXX_HAS_GENERIC_LAMBDA_CAPTURES
 # endif
+# if KE_GCC_AT_LEAST(5, 4)
+#  define KE_CXX_HAS_ALIAS_TEMPLATES
+# endif
 
 #elif defined(_MSC_VER)
 # if _MSC_VER >= 1600
@@ -135,6 +141,7 @@
 # if _MSC_VER >= 1800
 #  define KE_CXX_HAS_DELETE
 #  define KE_CXX_HAS_EXPLICIT_BOOL
+#  define KE_CXX_HAS_ALIAS_TEMPLATES
 # endif
 # if _MSC_VER == 1800 && _MSC_FULL_VER == 180021114
 #  define KE_CXX_HAS_CONSTEXPR
@@ -158,6 +165,9 @@
 #endif
 #if !defined(KE_CXX_HAS_EXPLICIT_BOOL)
 # error "AMTL requires C++11 explicit bool"
+#endif
+#if !defined(KE_CXX_HAS_ALIAS_TEMPLATES)
+# error "AMTL requires C++11 alias templates"
 #endif
 
 #if defined(KE_CXX_HAS_NOEXCEPT)

--- a/amtl/am-function.h
+++ b/amtl/am-function.h
@@ -69,10 +69,10 @@ public:
     : Callable()
   {}
   Callable(const Callable& other) {
-    assign(other.invoker_);
+    assign(other);
   }
   Callable(Callable&& other) {
-    assign(Move(other.invoker_));
+    assign(Forward<Callable>(other));
   }
   ~Callable()
   {}
@@ -84,6 +84,16 @@ public:
   ReturnType invoke(ParameterTypes&&... parameters) const {
     assert(can_invoke());
     return invoker_->invoke(Forward<ParameterTypes>(parameters)...);
+  }
+  void assign(const Callable& other) {
+    invoker_ = other.invoker_;
+  }
+  void assign(Callable&& other) {
+    invoker_ = Move(other.invoker_);
+  }
+protected:
+  void assign(Invoker* invoker) {
+    invoker_ = invoker;
   }
 
 public:
@@ -107,21 +117,12 @@ public:
     return *this;
   }
   Callable& operator=(const Callable& other) {
-    assign(other.invoker_);
+    assign(other);
     return *this;
   }
   Callable& operator=(Callable&& other) {
-    assign(Move(other.invoker_));
+    assign(Forward<Callable>(other));
     return *this;
-  }
-
-private:
-  void assign(RefPtr<Invoker>&& invoker) {
-    invoker_ = Forward<RefPtr<Invoker>>(invoker);
-  }
-protected:
-  void assign(Invoker* invoker) {
-    invoker_ = invoker;
   }
 
 private:

--- a/amtl/am-thread-posix.h
+++ b/amtl/am-thread-posix.h
@@ -162,11 +162,11 @@ class ConditionVariable : public Lockable
 class Thread
 {
   struct ThreadData {
-    ke::Function<void()> callback;
+    ke::Callable<void()> callback;
     char name[17];
   };
  public:
-  Thread(ke::Function<void()>&& callback, const char *name = nullptr) {
+  Thread(ke::Callable<void()>&& callback, const char *name = nullptr) {
     ThreadData *data = new ThreadData;
     data->callback = ke::Move(callback);
     snprintf(data->name, sizeof(data->name), "%s", name ? name : "");
@@ -205,7 +205,8 @@ class Thread
         fn(data->name);
 #endif
     }
-    data->callback();
+    if ((bool)data->callback)
+      data->callback();
     return nullptr;
   }
 

--- a/amtl/am-thread-windows.h
+++ b/amtl/am-thread-windows.h
@@ -115,8 +115,8 @@ class ConditionVariable : public Lockable
 class Thread
 {
  public:
-  Thread(ke::Function<void()>&& callback, const char *name = nullptr) {
-    auto ptr = new ke::Function<void()>(ke::Move(callback));
+  Thread(Callable<void()>&& callback, const char *name = nullptr) {
+    auto ptr = new ke::Callable<void()>(ke::Move(callback));
     thread_ = CreateThread(nullptr, 0, MainCallback, ptr, 0, nullptr);
     if (!thread_)
       delete ptr;
@@ -143,8 +143,9 @@ class Thread
 
  private:
   static DWORD WINAPI MainCallback(LPVOID arg) {
-    auto ptr = reinterpret_cast<ke::Lambda<void()>*>(arg);
-    (*ptr)();
+    auto ptr = reinterpret_cast<ke::Callable<void()>*>(arg);
+    if (ptr->can_invoke())
+      ptr->invoke();
     delete ptr;
     return 0;
   }

--- a/tests/test-autoptr.cpp
+++ b/tests/test-autoptr.cpp
@@ -68,7 +68,7 @@ class TestAutoPtr : public Test
     if (!check(*intp.get() == 7, "pointer should contain 7"))
       return false;
 
-    intp = new int[2];
+    intp = new int(2);
     if (!check(*intp.get() == 2, "pointer should contain 2"))
       return false;
 

--- a/tests/test-threadlocal-threaded.cpp
+++ b/tests/test-threadlocal-threaded.cpp
@@ -75,9 +75,7 @@ class TestThreadLocalThreaded : public Test
     sThreadVar = 10;
 
     VarThread run;
-    ke::AutoPtr<Thread> thread(new Thread([&run] () -> void {
-      run.Run();
-    }, "TestThreadLocal"));
+    ke::AutoPtr<Thread> thread(new Thread(FunctionPointer<void()>(&run, &VarThread::Run), "TestThreadLocal"));
     if (!check(thread->Succeeded(), "thread launched"))
       return false;
     thread->Join();

--- a/tests/test-threadutils.cpp
+++ b/tests/test-threadutils.cpp
@@ -120,9 +120,7 @@ class TestThreading : public Test
   {
     TestWorkerModel test;
 
-    ke::AutoPtr<Thread> thread(new Thread([&test] () -> void {
-      test.Run();
-    }, "TestWorkerModel"));
+    ke::AutoPtr<Thread> thread(new Thread(FunctionPointer<void()>(&test, &TestWorkerModel::Run), "TestWorkerModel"));
     if (!check(thread->Succeeded(), "thread launched"))
       return false;
 


### PR DESCRIPTION
This PR refactors am-function.h into (possibly messier but functional) header that allows:
1. All classes of am-function.h inherit a generic base class called Callable, this allows to receive callbacks without forcing a certain type being used (eg: Forcing Lambda class to be used).
2. Member function pointers can now be wrapped (like Lambdas/Functors/C function pointers were).

Edit 3: Note: Had to fix an AutoPtr test

Downside: This forces AMTL to require at least clang 3.3/gcc 5.4 or Visual Studio 2013
Note: Callable objects are wrapped as member function calls (as basically, that's what was originally being down, just explicitly).
