### PR TITLE
Fix HashSet::removeIfExists proxying wrong method

### DIFF
--- a/amtl/am-hashset.h
+++ b/amtl/am-hashset.h
@@ -90,7 +90,7 @@ class HashSet : private AllocPolicy
 
   template <typename Lookup>
   void removeIfExists(const Lookup &key) {
-    return table_.remove(key);
+    return table_.removeIfExists(key);
   }
 
   void remove(Result &r) {


### PR DESCRIPTION
Should call the equivalent function in HashTable.