### PR TITLE
Fix AutoPtr tests and indicate failed tests in return value

### DIFF
--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -48,11 +48,12 @@ int main(int argc, char **argv)
     fprintf(stdout, "Testing %s... \n", test->name());
     if (!test->Run()) {
       fprintf(stdout, "TEST:%s FAIL\n", test->name());
-      break;
+      return 1;
     }
     fprintf(stdout, "TEST:%s OK\n", test->name());
     test = test->next();
   }
+  return 0;
 }
 
 #if defined(__GNUC__)

--- a/tests/test-autoptr.cpp
+++ b/tests/test-autoptr.cpp
@@ -68,7 +68,7 @@ class TestAutoPtr : public Test
     if (!check(*intp.get() == 7, "pointer should contain 7"))
       return false;
 
-    intp = new int[2];
+    intp = new int(2);
     if (!check(*intp.get() == 2, "pointer should contain 2"))
       return false;
 


### PR DESCRIPTION
The testrunner main() always returned 0 even if there was a test
failing. Travis will now correctly indicate the build as failed, if
there is a test broken.