### PR TITLE
Add move constructor to HashTable, HashSet and HashMap

### DIFF
--- a/amtl/am-hashmap.h
+++ b/amtl/am-hashmap.h
@@ -140,8 +140,7 @@ class HashMap : private AllocPolicy
   }
   template <typename UK>
   bool add(Insert &i, UK &&key) {
-    V value;
-    Entry entry(ke::Forward<UK>(key), ke::Move(value));
+    Entry entry(ke::Forward<UK>(key), V());
     return table_.add(i, ke::Move(entry));
   }
 

--- a/amtl/am-hashmap.h
+++ b/amtl/am-hashmap.h
@@ -98,6 +98,11 @@ class HashMap : private AllocPolicy
   {
   }
 
+  HashMap(HashMap&& other)
+   : table_(ke::Move(other.table_))
+  {
+  }
+
   // capacity must be a power of two.
   bool init(size_t capacity = 16) {
     return table_.init(capacity);
@@ -135,7 +140,8 @@ class HashMap : private AllocPolicy
   }
   template <typename UK>
   bool add(Insert &i, UK &&key) {
-    Entry entry(ke::Forward<UK>(key), V());
+    V value;
+    Entry entry(ke::Forward<UK>(key), ke::Move(value));
     return table_.add(i, ke::Move(entry));
   }
 

--- a/amtl/am-hashset.h
+++ b/amtl/am-hashset.h
@@ -69,6 +69,11 @@ class HashSet : private AllocPolicy
   {
   }
 
+  HashSet(HashSet&& other)
+    : table_(ke::Move(other.table_))
+  {
+  }
+
   // capacity must be a power of two.
   bool init(size_t capacity = 16) {
     return table_.init(capacity);

--- a/amtl/am-hashtable.h
+++ b/amtl/am-hashtable.h
@@ -387,6 +387,21 @@ class HashTable : private AllocPolicy
   {
   }
 
+  HashTable(HashTable&& other)
+    : AllocPolicy(ke::Move(other)),
+      capacity_(other.capacity_),
+      nelements_(other.nelements_),
+      ndeleted_(other.ndeleted_),
+      table_(other.table_),
+      minCapacity_(other.minCapacity_)
+  {
+    other.capacity_ = 0;
+    other.nelements_ = 0;
+    other.ndeleted_ = 0;
+    other.table_ = nullptr;
+    other.minCapacity_ = kMinCapacity;
+  }
+
   ~HashTable()
   {
     for (uint32_t i = 0; i < capacity_; i++)

--- a/tests/test-callable.cpp
+++ b/tests/test-callable.cpp
@@ -131,12 +131,13 @@ class TestCallable : public Test
     };
 
     struct {
-      void *a, *b, *c, *d, *e, *f, *g;
+      int a;
+      void *b, *c, *d, *e, *f, *g;
       void *h, *j, *k, *m, *n, *o, *p;
-    } huge_struct;
+    } huge_struct = { 20 };
     CallDtorObj test_dtor;
     ptr = [huge_struct, test_dtor]() -> int {
-      return 20;
+      return huge_struct.a;
     };
     if (!check(!ptr.usingInlineStorage(), "huge lambda should not be using inline storage"))
       return false;


### PR DESCRIPTION
Allow nesting HashTable types and friends inside each other.

```cpp
typedef ke::HashSet<void*, ke::PointerPolicy<void>> NiceSet;
typedef ke::HashMap<int, NiceSet, IntegerPolicy> AwesomeMap;
```

That's your code @dvander 🥇 