### PR TITLE
Fix getting system error message on windows

### DIFF
--- a/amtl/os/am-system-errors.h
+++ b/amtl/os/am-system-errors.h
@@ -44,7 +44,7 @@ static inline void
 FormatSystemErrorCode(int code, char* error, size_t maxlength)
 {
 #if defined(KE_WINDOWS)
-  if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM|FORMAT_MESSAGE_IGNORE_INSERTS,
+  if (!FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM|FORMAT_MESSAGE_IGNORE_INSERTS,
                      nullptr,
                      code,
                      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),


### PR DESCRIPTION
A typo lead to always just writing "error code %08x" if FormatMessage was successful.