### PR TITLE
Fix build on non-Glibc systems

### DIFF
--- a/amtl/os/am-system-errors.h
+++ b/amtl/os/am-system-errors.h
@@ -55,7 +55,7 @@ FormatSystemErrorCode(int code, char* error, size_t maxlength)
     SafeSprintf(error, maxlength, "error code %08x", code);
     return;
   }
-#elif defined(KE_LINUX)
+#elif defined(KE_LINUX) && defined(__GLIBC__)
   const char* ptr = strerror_r(code, error, maxlength);
   if (ptr != error)
     ke::SafeSprintf(error, maxlength, "%s", ptr);


### PR DESCRIPTION
strerror_r with char* return type is a GNU specific extension.

https://linux.die.net/man/3/strerror_r