### PR TITLE
Add a new Flags<T> wrapper for scoped enumerations that contain bitwise flags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.gdb_history

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -60,6 +60,8 @@ class KEConfig(object):
       if have_clang or (have_gcc and cxx.majorVersion >= 4):
         cfg.cflags += ['-fvisibility=hidden']
         cfg.cxxflags += ['-fvisibility-inlines-hidden']
+        # -Wunused-function breaks test_flags.cpp
+        cfg.cxxflags += ['-Wno-unused-function']
 
       cfg.cxxflags += [
         '-fno-exceptions',

--- a/README.md
+++ b/README.md
@@ -261,6 +261,14 @@ Note that AutoPtr is not similar to the C++03 `auto_ptr` class. It is simply a s
 permissive UniquePtr. It is intended for code that benefits from automatic deletion, but
 not from the verbosity introduced by some of UniquePtr's safety features.
 
+### Flags (am-flags.h)
+
+`Flags<T>` is a container class for a scoped enum type (that is, an enum declared as `enum class`).
+It is meant to be used in addition to (or as a replacement of) `KE_DEFINE_ENUM_OPERATORS`. It is
+designed for enums where each member is a bit or bitmask. Flags provides type-safe bitwise
+operations, and most importantly, an implicit cast-to-bool operator which is not allowed for
+normal C++ enumerations.
+
 # Replacing SourceHook Includes
 
 AMTL is a spiritual successor to the SourceHook template library, used in many AlliedModders
@@ -313,6 +321,13 @@ variables, you might consider simply linking objects together using RAII and avo
 entirely (though CStack will have better cache performance if you need to walk the list of entries).
 
 If you don't need stable pointers, CStack can be replaced with ke::Vector.
+
+# Compile-Time Options
+
+- `KE_ALLOW_STD_CXX` - In some cases, STL is implemented using compiler intrinsics, and therefore
+  certain features are not possible to implement without using STL. An example of this would be
+  std::underlying\_type. AMTL will try to use an intrinsic if available, but if for some reason
+  it does not work, you can enable the STL version with this macro.
 
 # License
 

--- a/amtl/am-cxx.h
+++ b/amtl/am-cxx.h
@@ -205,44 +205,4 @@
 # define KE_LINKONCE(x) x __attribute__((weak))
 #endif
 
-#define KE_DEFINE_ENUM_OPERATORS(EnumName)                                          \
-  static inline EnumName operator |(const EnumName &left, const EnumName &right) {  \
-    return EnumName(uint32_t(left) | uint32_t(right));                              \
-  }                                                                                 \
-  static inline EnumName operator &(const EnumName &left, const EnumName &right) {  \
-    return EnumName(uint32_t(left) & uint32_t(right));                              \
-  }                                                                                 \
-  static inline EnumName operator ^(const EnumName &left, const EnumName &right) {  \
-    return EnumName(uint32_t(left) ^ uint32_t(right));                              \
-  }                                                                                 \
-  static inline EnumName operator ~(const EnumName &flags) {                        \
-    return EnumName(~uint32_t(flags));                                              \
-  }                                                                                 \
-  static inline EnumName & operator |=(EnumName &left, const EnumName &right) {     \
-    return left = left | right;                                                     \
-  }                                                                                 \
-  static inline EnumName & operator &=(EnumName &left, const EnumName &right) {     \
-    return left = left & right;                                                     \
-  }                                                                                 \
-  static inline EnumName & operator ^=(EnumName &left, const EnumName &right) {     \
-    return left = left ^ right;                                                     \
-  }                                                                                 \
-  static inline bool operator !(const EnumName &obj) {                              \
-    return uint32_t(obj) == 0;                                                      \
-  }
-
-#define KE_DEFINE_ENUM_COMPARATORS(EnumName, Type)                                  \
-  static inline bool operator ==(const EnumName& left, const Type& right) {         \
-    return Type(left) == right;                                                     \
-  }                                                                                 \
-  static inline bool operator ==(const Type& left, const EnumName& right) {         \
-    return left == Type(right);                                                     \
-  }                                                                                 \
-  static inline bool operator !=(const EnumName& left, const Type& right) {         \
-    return Type(left) != right;                                                     \
-  }                                                                                 \
-  static inline bool operator !=(const Type& left, const EnumName& right) {         \
-    return left != Type(right);                                                     \
-  }
-
 #endif // _include_amtl_cxx_support_h_

--- a/amtl/am-enum.h
+++ b/amtl/am-enum.h
@@ -1,0 +1,92 @@
+// vim: set sts=8 ts=2 sw=2 tw=99 et:
+//
+// Copyright (C) 2014, David Anderson and AlliedModders LLC
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+//  * Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  * Neither the name of AlliedModders LLC nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifndef _include_amtl_enum_h_
+#define _include_amtl_enum_h_
+
+#ifdef KE_ALLOW_STD_CXX
+# include <type_traits>
+#endif
+
+namespace ke {
+  template <typename T>
+  struct enum_integral_type {
+#ifdef KE_ALLOW_STD_CXX
+    using type = std::underlying_type<T>::type;
+#else
+    using type = __underlying_type(T);
+#endif
+  };
+} // namespace ke
+
+#define KE_DEFINE_ENUM_OPERATORS(EnumName)                                          \
+  static inline EnumName operator |(const EnumName &left, const EnumName &right) {  \
+    typedef ke::enum_integral_type<EnumName>::type int_type;                        \
+    return EnumName(int_type(left) | int_type(right));                              \
+  }                                                                                 \
+  static inline EnumName operator &(const EnumName &left, const EnumName &right) {  \
+    typedef ke::enum_integral_type<EnumName>::type int_type;                        \
+    return EnumName(int_type(left) & int_type(right));                              \
+  }                                                                                 \
+  static inline EnumName operator ^(const EnumName &left, const EnumName &right) {  \
+    typedef ke::enum_integral_type<EnumName>::type int_type;                        \
+    return EnumName(int_type(left) ^ int_type(right));                              \
+  }                                                                                 \
+  static inline EnumName operator ~(const EnumName &flags) {                        \
+    typedef ke::enum_integral_type<EnumName>::type int_type;                        \
+    return EnumName(~int_type(flags));                                              \
+  }                                                                                 \
+  static inline EnumName & operator |=(EnumName &left, const EnumName &right) {     \
+    return left = left | right;                                                     \
+  }                                                                                 \
+  static inline EnumName & operator &=(EnumName &left, const EnumName &right) {     \
+    return left = left & right;                                                     \
+  }                                                                                 \
+  static inline EnumName & operator ^=(EnumName &left, const EnumName &right) {     \
+    return left = left ^ right;                                                     \
+  }                                                                                 \
+  static inline bool operator !(const EnumName &obj) {                              \
+    typedef ke::enum_integral_type<EnumName>::type int_type;                        \
+    return int_type(obj) == 0;                                                      \
+  }
+
+#define KE_DEFINE_ENUM_COMPARATORS(EnumName, Type)                                  \
+  static inline bool operator ==(const EnumName& left, const Type& right) {         \
+    return Type(left) == right;                                                     \
+  }                                                                                 \
+  static inline bool operator ==(const Type& left, const EnumName& right) {         \
+    return left == Type(right);                                                     \
+  }                                                                                 \
+  static inline bool operator !=(const EnumName& left, const Type& right) {         \
+    return Type(left) != right;                                                     \
+  }                                                                                 \
+  static inline bool operator !=(const Type& left, const EnumName& right) {         \
+    return left != Type(right);                                                     \
+  }
+
+#endif // _include_amtl_enum_h_

--- a/amtl/am-flags.h
+++ b/amtl/am-flags.h
@@ -1,0 +1,129 @@
+// vim: set sts=8 ts=2 sw=2 tw=99 et:
+//
+// Copyright (C) 2013-2014, David Anderson and AlliedModders LLC
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  * Neither the name of AlliedModders LLC nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifndef _include_amtl_flags_h_
+#define _include_amtl_flags_h_
+
+#include <amtl/am-enum.h>
+
+namespace ke {
+
+// This is a wrapper intended for use with typed/scoped enums in C++11. Since
+// enum classes cannot be implicitly converted to bool, it makes patterns like
+// |if (x & y)| possible without !!.
+//
+// Note that we explicitly don't expose an operator T here, since it creates
+// ambiguous operator overloads if using KE_DEFINE_ENUM_OPERATORS.
+template <typename T>
+class Flags
+{
+public:
+  Flags()
+    : value_(static_cast<T>(0))
+  {}
+
+  // Note: these are not explicit since we want operators below to support
+  // both Flags and the underlying T type.
+  Flags(const T& t)
+    : value_(t)
+  {}
+  Flags(const Flags& other)
+    : value_(other.value_)
+  {}
+
+  using IntType = typename enum_integral_type<T>::type;
+
+  explicit operator bool() const {
+    return value_ != static_cast<T>(0);
+  }
+  bool operator !() const {
+    return value_ == static_cast<T>(0);
+  }
+
+  IntType bits() const {
+    return static_cast<IntType>(value_);
+  }
+  T get() const {
+    return value_;
+  }
+
+  Flags operator +(const Flags& other) const {
+    return Flags(static_cast<T>(bits() | other.bits()));
+  }
+  Flags operator -(const Flags& other) const {
+    return Flags(static_cast<T>(bits() & (bits() ^ other.bits())));
+  }
+  Flags operator |(const Flags& other) const {
+    return Flags(static_cast<T>(bits() | other.bits()));
+  }
+  Flags operator &(const Flags& other) const {
+    return Flags(static_cast<T>(bits() & other.bits()));
+  }
+  Flags operator ^(const Flags& other) const {
+    return Flags(static_cast<T>(bits() ^ other.bits()));
+  }
+  bool operator ==(const Flags& other) const {
+    return value_ == other.value_;
+  }
+  bool operator !=(const Flags& other) const {
+    return value_ != other.value_;
+  }
+
+  Flags& operator +=(const Flags& other) {
+    *this = *this + other;
+    return *this;
+  }
+  Flags& operator -=(const Flags& other) {
+    *this = *this - other;
+    return *this;
+  }
+  Flags& operator |=(const Flags& other) {
+    *this = *this | other;
+    return *this;
+  }
+  Flags& operator &=(const Flags& other) {
+    *this = *this & other;
+    return *this;
+  }
+  Flags& operator ^=(const Flags& other) {
+    *this = *this ^ other;
+    return *this;
+  }
+
+  Flags& operator =(const Flags& other) {
+    value_ = other.value_;
+    return *this;
+  }
+
+private:
+  T value_;
+};
+
+} // namespace ke
+
+#endif // _include_amtl_flags_h_

--- a/tests/AMBuild.tests
+++ b/tests/AMBuild.tests
@@ -47,6 +47,7 @@ binary.sources += [
   'test-string.cpp',
   'test-autoptr.cpp',
   'test-uniqueptr.cpp',
+  'test-flags.cpp',
 ]
 
 builder.Add(binary)

--- a/tests/test-flags.cpp
+++ b/tests/test-flags.cpp
@@ -1,0 +1,96 @@
+// vim: set sts=8 ts=2 sw=2 tw=99 et:
+//
+// Copyright (C) 2013, David Anderson and AlliedModders LLC
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+//  * Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  * Neither the name of AlliedModders LLC nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <am-flags.h>
+#include <stdint.h>
+#include "runner.h"
+
+using namespace ke;
+
+enum class Scoped : uint32_t
+{
+  Flag0 = (1 << 0),
+  Flag1 = (1 << 1),
+  Flag2 = (1 << 2),
+  Flag3 = (1 << 3)
+};
+KE_DEFINE_ENUM_OPERATORS(Scoped)
+
+class TestFlags : public Test
+{
+ public:
+  TestFlags()
+    : Test("Flags")
+  {}
+
+  bool Run() override {
+    if (!testBasic())
+      return false;
+    return true;
+  }
+
+ private:
+  bool testBasic() {
+    Flags<Scoped> flags;
+    if (!check(!flags, "empty flags is false"))
+      return false;
+    if (flags && !check(false, "empty flags is false 2"))
+      return false;
+
+    flags += Scoped::Flag0;
+    if (!check((bool)flags, "empty flags is true"))
+      return false;
+
+    flags += Scoped::Flag1;
+
+    Flags<Scoped> other(Scoped::Flag1 | Scoped::Flag2);
+    if (!check(flags != other, "different flags are not equal"))
+      return false;
+    if (!check(other.bits() == 0x6, "flag bits == 0x6"))
+      return false;
+
+    flags -= other;
+    if (!check(flags == Scoped::Flag0, "operator -="))
+      return false;
+
+    uint32_t value = flags.bits();
+    if (!check(value == 0x1, "flag bits are 0x1"))
+      return false;
+
+    flags |= other;
+    if (!check(flags.bits() == 0x7, "flag bits are 0x7 after adding"))
+      return false;
+
+    flags &= other;
+    if (!check(flags.bits() == 0x6, "flag bits are 0x6 after anding"))
+      return false;
+
+    return true;
+  }
+} sTestFlags;


### PR DESCRIPTION
Explanation is in README.md. This is meant to solve the following pattern, since C++ does not have any way to make scoped enums implicitly convertible to bool:

```
enum class Blah {
    None = 0,
    Flag1 = 0x1
};

Blah flags = Blag::None;
if (!!flags) ...
```

We can now use:
```
enum class Blah {
    None = 0,
    Flag1 = 0x1
};

Flags<Blah> flags = Blag::None;
if (!flags) ...
```

This patch also fixes a bug where `KE_DEFINE_NUM_OPERATORS` assumed the enum fields fit in `uint32_t`.