### PR TITLE
Add sprintf functions that will allocate a best-fit buffer.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -62,6 +62,8 @@ class KEConfig(object):
         cfg.cxxflags += ['-fvisibility-inlines-hidden']
         # -Wunused-function breaks test_flags.cpp
         cfg.cxxflags += ['-Wno-unused-function']
+      if have_clang:
+        cfg.cxxflags += ['-Wno-implicit-exception-spec-mismatch']
 
       cfg.cxxflags += [
         '-fno-exceptions',

--- a/amtl/am-uniqueptr.h
+++ b/amtl/am-uniqueptr.h
@@ -50,8 +50,10 @@ class UniquePtr
   }
   explicit UniquePtr(T *t)
    : t_(t)
-  {
-  }
+  {}
+  UniquePtr(decltype(nullptr) n)
+   : t_(nullptr)
+  {}
   UniquePtr(UniquePtr &&other)
   {
     t_ = other.t_;

--- a/tests/test-string.cpp
+++ b/tests/test-string.cpp
@@ -28,6 +28,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include <am-string.h>
+#include <limits.h>
 #include "runner.h"
 
 using namespace ke;
@@ -49,9 +50,25 @@ class TestString : public Test
     return true;
   }
 
+  bool testAllocating() const {
+    int a = INT_MAX;
+    const char* value = "Hello this is a test.";
+    const char* expect = "A: 2147483647 B: Hello this is a test.";
+    UniquePtr<char[]> ptr = Sprintf("A: %d B: %s", a, value);
+    if (!check(strcmp(ptr.get(), expect) == 0, expect))
+      return false;
+
+    UniquePtr<AString> str = AString::Sprintf("A: %d B: %s", a, value);
+    if (!check(str->compare(expect) == 0, expect))
+      return false;
+    return true;
+  }
+
   bool Run() override
   {
     if (!testSprintf())
+      return false;
+    if (!testAllocating())
       return false;
     return true;
   };


### PR DESCRIPTION
This adds `Sprintf` and `SprintfArgs` which will return a `UniquePtr<char[]>` containing the formatted string. It's intended for cases where a `SafeSprintf` truncating is not desirable. There are also `AString` variants as well.

In addition this patch removes an `AutoPtr` instance.