### PR TITLE
Add a simple command-line argv parser, similar to Python's argparse.

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,12 @@ designed for enums where each member is a bit or bitmask. Flags provides type-sa
 operations, and most importantly, an implicit cast-to-bool operator which is not allowed for
 normal C++ enumerations.
 
+### args::Parser (experimental/am-argparser.h)
+
+This is currently experimental. It is a command-line argv parser similar to Python's argparse
+library. It is designed to handle a few basic cases and will be expanded as needed. Examples
+of how to use it are in test-argparse.cpp.
+
 # Replacing SourceHook Includes
 
 AMTL is a spiritual successor to the SourceHook template library, used in many AlliedModders

--- a/amtl/am-string.h
+++ b/amtl/am-string.h
@@ -47,6 +47,9 @@
 #include <string.h>
 #include <stdarg.h>
 #include <stdint.h>
+#if !defined(_MSC_VER)
+# include <strings.h>
+#endif
 
 namespace ke {
 
@@ -344,6 +347,16 @@ SafeStrcpy(char* dest, size_t maxlength, const char* src)
   *iter = '\0';
 
   return iter - dest;
+}
+
+static inline int
+StrCaseCmp(const char* a, const char* b)
+{
+#if defined(_MSC_VER)
+  return strcmpi(a, b);
+#else
+  return strcasecmp(a, b);
+#endif
 }
 
 // Split a string into a vector of strings. The |split| argument must contain

--- a/tests/AMBuild.tests
+++ b/tests/AMBuild.tests
@@ -48,6 +48,7 @@ binary.sources += [
   'test-autoptr.cpp',
   'test-uniqueptr.cpp',
   'test-flags.cpp',
+  'test-argparser.cpp',
 ]
 
 builder.Add(binary)

--- a/tests/test-argparser.cpp
+++ b/tests/test-argparser.cpp
@@ -1,0 +1,256 @@
+// vim: set sts=8 ts=2 sw=2 tw=99 et:
+//
+// Copyright (C) 2013, David Anderson and AlliedModders LLC
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+//  * Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  * Neither the name of AlliedModders LLC nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <experimental/am-argparser.h>
+#include <limits.h>
+#include "runner.h"
+
+using namespace ke;
+using namespace ke::args;
+
+class TestArgparser : public Test
+{
+ public:
+  TestArgparser()
+   : Test("Argparser")
+  {
+  }
+
+  bool testBasic() {
+    Parser parser("help");
+
+    if (!check(parser.parsev(nullptr) == true, "parse no args"))
+      return false;
+    if (!check(parser.parsev("asdf", nullptr) == false, "error on parse extra args"))
+      return false;
+    if (!check(parser.parsev("--asdf", nullptr) == false, "error on parse unknown arg"))
+      return false;
+    return true;
+  }
+
+  bool testBoolArg() {
+    Parser parser("help");
+
+    BoolOption no_default(parser,
+      "b", "bool",
+      Nothing(),
+      "help");
+    BoolOption default_true(parser,
+      "t", "default-true",
+      Some(true),
+      "help");
+    BoolOption default_false(parser,
+      "f", "default-false",
+      Some(false),
+      "help");
+
+    if (!check(parser.parsev(nullptr) == true, "parse 1 succeeded"))
+      return false;
+    if (!check(no_default.hasValue() == false, "no_default has no value"))
+      return false;
+    if (!check(default_true.hasValue() == true, "default_true has value"))
+      return false;
+    if (!check(default_true.hasUserValue() == false, "default_true has no user value"))
+      return false;
+    if (!check(default_true.value() == true, "default_true is true"))
+      return false;
+    if (!check(default_false.hasValue() == true, "default_false has value"))
+      return false;
+    if (!check(default_false.hasUserValue() == false, "default_false has no user value"))
+      return false;
+    if (!check(default_false.value() == false, "default_false is false"))
+      return false;
+
+    parser.reset();
+    if (!check(parser.parsev("-b", nullptr) == true, "parse 2 succeeded"))
+      return false;
+    if (!check(no_default.hasValue() == true, "no_default has value"))
+      return false;
+    if (!check(no_default.value() == true, "no_default is true"))
+      return false;
+    if (!check(default_true.hasUserValue() == false, "default_true has no user value"))
+      return false;
+    if (!check(default_false.hasUserValue() == false, "default_false has no user value"))
+      return false;
+
+    parser.reset();
+    if (!check(parser.parsev("--bool=false", nullptr) == true, "parse 3 succeeded"))
+      return false;
+    if (!check(no_default.value() == false, "no_default is false"))
+      return false;
+
+    parser.reset();
+    if (!check(parser.parsev("--bool", "false", nullptr) == true, "parse 4 succeeded"))
+      return false;
+    if (!check(no_default.value() == false, "no_default is false"))
+      return false;
+
+    parser.reset();
+    if (!check(parser.parsev("-b", "true", nullptr) == true, "parse 5 succeeded"))
+      return false;
+    if (!check(no_default.value() == true, "no_default is false"))
+      return false;
+
+    parser.reset();
+    if (!check(parser.parsev("-f", nullptr) == true, "parse 6 succeeded"))
+      return false;
+    if (!check(default_false.value() == true, "default_false is true"))
+      return false;
+
+    parser.reset();
+    if (!check(parser.parsev("--default-true=false", nullptr) == true, "parse 7 succeeded"))
+      return false;
+    if (!check(default_true.value() == false, "default_true is false"))
+      return false;
+
+    return true;
+  }
+
+  bool testToggleArg() {
+    Parser parser("help");
+
+    ToggleOption x(parser,
+      "x", nullptr,
+      Nothing(),
+      "help");
+    ToggleOption y(parser,
+      "y", nullptr,
+      Some(true),
+      "help");
+    ToggleOption z(parser,
+      "z", nullptr,
+      Some(false),
+      "help");
+
+    parser.reset();
+    if (!check(parser.parsev(nullptr) == true, "toggle parse 1 succeeded"))
+      return false;
+    if (!check(x.value() == false, "x is false"))
+      return false;
+
+    parser.reset();
+    if (!check(parser.parsev("-x", nullptr) == true, "toggle parse 2 succeeded"))
+      return false;
+    if (!check(x.value() == true, "x is true"))
+      return false;
+
+    parser.reset();
+    if (!check(parser.parsev("-y", nullptr) == true, "toggle parse 3 succeeded"))
+      return false;
+    if (!check(y.value() == false, "y is false"))
+      return false;
+
+    parser.reset();
+    if (!check(parser.parsev("-z", nullptr) == true, "toggle parse 4 succeeded"))
+      return false;
+    if (!check(z.value() == true, "z is true"))
+      return false;
+
+    parser.reset();
+    if (!check(parser.parsev("-z=false", nullptr) == false, "toggle parse 5 failed"))
+      return false;
+
+    return true;
+  }
+
+  bool testStringArg() {
+    Parser parser("help");
+
+    StringOption s(parser,
+      "s", "string",
+      Nothing(),
+      "help");
+    StringOption t(parser,
+      "t", "ttt",
+      Some(AString("whatever")),
+      "help");
+    StringOption mode(parser, "mode", "help");
+
+    parser.reset();
+    if (!check(parser.parsev(nullptr) == false, "string parse 1 failed"))
+      return false;
+
+    parser.reset();
+    if (!check(parser.parsev("crab", nullptr) == true, "string parse 2 succeeded"))
+      return false;
+    if (!check(s.hasValue() == false, "string is false"))
+      return false;
+    if (!check(t.value().compare("whatever") == 0, "ttt is 'whatever'"))
+      return false;
+    if (!check(mode.value().compare("crab") == 0, "mode is 'crab'"))
+      return false;
+
+    parser.reset();
+    if (!check(parser.parsev("-s", "yam", "egg", nullptr) == true, "string parse 3 succeeded"))
+      return false;
+    if (!check(s.value().compare("yam") == 0, "string is 'yam'"))
+      return false;
+    if (!check(mode.value().compare("egg") == 0, "mode is 'crab'"))
+      return false;
+
+    return true;
+  }
+
+  bool testIntArg() {
+    Parser parser("help");
+
+    IntOption val1(parser,
+      nullptr, "val",
+      Nothing(),
+      "help");
+
+    parser.reset();
+    if (!check(parser.parsev("--val", "308", nullptr) == true, "int parse 1 succeeded"))
+      return false;
+    if (!check(val1.value() == 308, "value is 308"))
+      return false;
+
+    parser.reset();
+    if (!check(parser.parsev("--val", "30x", nullptr) == false, "int parse 2 failed"))
+      return false;
+
+    return true;
+  }
+
+  bool Run() override
+  {
+    if (!testBasic())
+      return false;
+    if (!testBoolArg())
+      return false;
+    if (!testToggleArg())
+      return false;
+    if (!testStringArg())
+      return false;
+    if (!testIntArg())
+      return false;
+    return true;
+  };
+} sTestArgparser;
+


### PR DESCRIPTION
This is not the most glamorous utility class but it will help make our command-line tools a lot prettier. It does not support repeated arguments or trailing arguments (yet), so ironically I didn't use it in AMTL's testrunner. The first consumer will be spshell.