### PR TITLE
Redo the argparser type system.

### DIFF
--- a/tests/test-argparser.cpp
+++ b/tests/test-argparser.cpp
@@ -241,7 +241,7 @@ class TestArgparser : public Test
   bool testRepeatArg() {
     Parser parser("help");
 
-    RepeatOption<StringValue> inc(parser,
+    RepeatOption<AString> inc(parser,
       "-i", "--include-path",
       "Include path.");
 


### PR DESCRIPTION
And this is why argparser is "experimental". Having to type `Option<IntValue>` is weird, and I didn't fully notice it until `RepeatOption` came along. I think a more normal thing to do is to have `Option<int>` and then have the template derive a value policy from the input type.

This patch accomplishes that.