### PR TITLE
Restyle to use |T*| and |T&| instead of |T *| and |T &|.

### DIFF
--- a/amtl/am-algorithm.h
+++ b/amtl/am-algorithm.h
@@ -35,19 +35,19 @@
 namespace ke {
 
 template <typename T> static inline T
-Min(const T &t1, const T &t2)
+Min(const T& t1, const T& t2)
 {
     return t1 < t2 ? t1 : t2;
 }
 
 template <typename T> static inline T
-Max(const T &t1, const T &t2)
+Max(const T& t1, const T& t2)
 {
     return t1 > t2 ? t1 : t2;
 }
 
 template <typename T> static inline void
-Swap(T &left, T &right)
+Swap(T& left, T& right)
 {
   T tmp(Move(left));
   left = Move(right);

--- a/amtl/am-allocator-policies.h
+++ b/amtl/am-allocator-policies.h
@@ -49,18 +49,18 @@ class SystemAllocatorPolicy
     }
 
   public:
-    void am_free(void *memory) {
+    void am_free(void* memory) {
 #if defined(_DEBUG) && defined(_CRTDBG_MAP_ALLOC)
       free(memory);
 #else
       ::free(memory);
 #endif
     }
-    void *am_malloc(size_t bytes) {
+    void* am_malloc(size_t bytes) {
 #if defined(_DEBUG) && defined(_CRTDBG_MAP_ALLOC)
-      void *ptr = malloc(bytes);
+      void* ptr = malloc(bytes);
 #else
-      void *ptr = ::malloc(bytes);
+      void* ptr = ::malloc(bytes);
 #endif
       if (!ptr)
         reportOutOfMemory();

--- a/amtl/am-arithmetic.h
+++ b/amtl/am-arithmetic.h
@@ -34,7 +34,7 @@
 namespace ke {
 
 static inline bool
-TryUint64Multiply(uint64_t left, uint64_t right, uint64_t *out)
+TryUint64Multiply(uint64_t left, uint64_t right, uint64_t* out)
 {
   uint64_t r = left * right;
   if (r != 0 && ((r / left) != right))
@@ -45,7 +45,7 @@ TryUint64Multiply(uint64_t left, uint64_t right, uint64_t *out)
 }
 
 static inline bool
-TryUint32Add(uint32_t left, uint32_t right, uint32_t *out)
+TryUint32Add(uint32_t left, uint32_t right, uint32_t* out)
 {
   if (left + right < Max(left, right))
     return false;
@@ -54,7 +54,7 @@ TryUint32Add(uint32_t left, uint32_t right, uint32_t *out)
 }
 
 static inline bool
-TryUint64Add(uint64_t left, uint64_t right, uint64_t *out)
+TryUint64Add(uint64_t left, uint64_t right, uint64_t* out)
 {
   if (left + right < Max(left, right))
     return false;

--- a/amtl/am-atomics-no-stl.h
+++ b/amtl/am-atomics-no-stl.h
@@ -39,10 +39,10 @@ namespace ke {
 
 #if defined(KE_CXX_MSVC)
 extern "C" {
-  long __cdecl _InterlockedIncrement(long volatile *dest);
-  long __cdecl _InterlockedDecrement(long volatile *dest);
-  long long __cdecl _InterlockedIncrement64(long long volatile *dest);
-  long long __cdecl _InterlockedDecrement64(long long volatile *dest);
+  long __cdecl _InterlockedIncrement(long volatile* dest);
+  long __cdecl _InterlockedDecrement(long volatile* dest);
+  long long __cdecl _InterlockedIncrement64(long long volatile* dest);
+  long long __cdecl _InterlockedDecrement64(long long volatile* dest);
 }
 # pragma intrinsic(_InterlockedIncrement)
 # pragma intrinsic(_InterlockedDecrement)
@@ -61,10 +61,10 @@ struct AtomicOps<4>
 #if defined(KE_CXX_MSVC)
   typedef volatile long Type;
 
-  static Type Increment(Type *ptr) {
+  static Type Increment(Type* ptr) {
     return _InterlockedIncrement(ptr);
   }
-  static Type Decrement(Type *ptr) {
+  static Type Decrement(Type* ptr) {
     return _InterlockedDecrement(ptr);
   };
 #elif defined(KE_CXX_LIKE_GCC)
@@ -73,10 +73,10 @@ struct AtomicOps<4>
   // x86/x64 notes: When using GCC < 4.8, this will compile to a spinlock.
   // On 4.8+, or when using Clang, we'll get the more optimal "lock addl"
   // variant.
-  static Type Increment(Type *ptr) {
+  static Type Increment(Type* ptr) {
     return __sync_add_and_fetch(ptr, 1);
   }
-  static Type Decrement(Type *ptr) {
+  static Type Decrement(Type* ptr) {
     return __sync_sub_and_fetch(ptr, 1);
   }
 #endif
@@ -88,10 +88,10 @@ struct AtomicOps<8>
 #if defined(KE_CXX_MSVC)
   typedef volatile long long Type;
 
-  static Type Increment(Type *ptr) {
+  static Type Increment(Type* ptr) {
     return _InterlockedIncrement64(ptr);
   }
-  static Type Decrement(Type *ptr) {
+  static Type Decrement(Type* ptr) {
     return _InterlockedDecrement64(ptr);
   };
 #elif defined(KE_CXX_LIKE_GCC)
@@ -100,10 +100,10 @@ struct AtomicOps<8>
   // x86/x64 notes: When using GCC < 4.8, this will compile to a spinlock.
   // On 4.8+, or when using Clang, we'll get the more optimal "lock addl"
   // variant.
-  static Type Increment(Type *ptr) {
+  static Type Increment(Type* ptr) {
     return __sync_add_and_fetch(ptr, 1);
   }
-  static Type Decrement(Type *ptr) {
+  static Type Decrement(Type* ptr) {
     return __sync_sub_and_fetch(ptr, 1);
   }
 #endif

--- a/amtl/am-atomics.h
+++ b/amtl/am-atomics.h
@@ -39,7 +39,7 @@
 #if defined(KE_CXX_MSVC)
 extern "C" {
   void * __cdecl _InterlockedCompareExchangePointer(
-     void * volatile *Destination,
+     void * volatile* Destination,
      void * Exchange,
      void * Comparand
   );
@@ -70,14 +70,14 @@ extern "C" {
 namespace ke {
 
 #if defined(KE_CXX_MSVC)
-static inline void *
-CompareAndSwapPtr(void *volatile *Destination, void *Exchange, void *Comparand)
+static inline void*
+CompareAndSwapPtr(void* volatile* Destination, void* Exchange, void* Comparand)
 {
   return _InterlockedCompareExchangePointer(Destination, Exchange, Comparand);
 }
 #else
-static inline void *
-CompareAndSwapPtr(void *volatile *dest, void *newval, void *oldval)
+static inline void*
+CompareAndSwapPtr(void* volatile* dest, void* newval, void* oldval)
 {
   return __sync_val_compare_and_swap(dest, oldval, newval);
 }

--- a/amtl/am-autoptr.h
+++ b/amtl/am-autoptr.h
@@ -49,7 +49,7 @@ class AutoPtr
    : t_(nullptr)
   {
   }
-  explicit AutoPtr(T *t)
+  explicit AutoPtr(T* t)
    : t_(t)
   {
   }
@@ -57,23 +57,23 @@ class AutoPtr
    : t_(other.take())
   {
   }
-  AutoPtr(AutoPtr &&other)
+  AutoPtr(AutoPtr&& other)
    : t_(other.take())
   {
   }
   ~AutoPtr() {
     delete t_;
   }
-  T *get() const {
+  T* get() const {
     return t_;
   }
-  T *take() {
+  T* take() {
     return ReturnAndVoid(t_);
   }
-  T *operator *() const {
+  T* operator*() const {
     return t_;
   }
-  T *operator ->() const {
+  T* operator ->() const {
     return t_;
   }
   operator T* () const {
@@ -91,11 +91,11 @@ class AutoPtr
     assign(t);
     return *this;
   }
-  AutoPtr& operator =(AutoPtr &&other) {
+  AutoPtr& operator =(AutoPtr&& other) {
     assign(other.take());
     return *this;
   }
-  AutoPtr& operator =(UniquePtr<T> &&other) {
+  AutoPtr& operator =(UniquePtr<T>&& other) {
     assign(other.take());
     return *this;
   }
@@ -104,11 +104,11 @@ class AutoPtr
   }
 
  private:
-  AutoPtr(const AutoPtr &other) = delete;
-  AutoPtr &operator =(const AutoPtr &other) = delete;
+  AutoPtr(const AutoPtr& other) = delete;
+  AutoPtr& operator =(const AutoPtr& other) = delete;
 
  private:
-  T *t_;
+  T* t_;
 };
 
 // Wrapper that automatically deletes its contents. The pointer can be taken
@@ -129,20 +129,20 @@ class AutoPtr<T[]>
    : t_(other.take())
   {
   }
-  explicit AutoPtr(T *t)
+  explicit AutoPtr(T* t)
    : t_(t)
   {
   }
   ~AutoPtr() {
     delete [] t_;
   }
-  T *get() const {
+  T* get() const {
     return t_;
   }
-  T *take() {
+  T* take() {
     return ReturnAndVoid(t_);
   }
-  T *forget() {
+  T* forget() {
     return ReturnAndVoid(t_);
   }
   explicit operator bool() const {
@@ -176,7 +176,7 @@ class AutoPtr<T[]>
   AutoPtr& operator =(const AutoPtr& other) = delete;
 
  private:
-  T *t_;
+  T* t_;
 };
 
 } // namespace ke

--- a/amtl/am-bits.h
+++ b/amtl/am-bits.h
@@ -41,7 +41,7 @@
 
 namespace ke {
 
-static const size_t kMallocAlignment = sizeof(void *) * 2;
+static const size_t kMallocAlignment = sizeof(void*) * 2;
 
 static const size_t kKB = 1024;
 static const size_t kMB = 1024 * kKB;
@@ -204,11 +204,11 @@ IsAligned(T addr, size_t alignment)
     return !(uintptr_t(addr) & (alignment - 1));
 }
 
-static inline void *
-AlignedBase(void *addr, size_t alignment)
+static inline void*
+AlignedBase(void* addr, size_t alignment)
 {
     assert(IsPowerOfTwo(alignment));
-    return reinterpret_cast<void *>(uintptr_t(addr) & ~(alignment - 1));
+    return reinterpret_cast<void*>(uintptr_t(addr) & ~(alignment - 1));
 }
 
 } // namespace ke

--- a/amtl/am-deque.h
+++ b/amtl/am-deque.h
@@ -52,7 +52,7 @@ class Deque : private AllocPolicy
      last_(0)
   {
   }
-  Deque(Deque &&other)
+  Deque(Deque&& other)
    : AllocPolicy(Move(other)),
      buffer_(other.buffer_),
      maxlength_(other.maxlength_),
@@ -65,7 +65,7 @@ class Deque : private AllocPolicy
     zap();
   }
 
-  Deque &operator =(Deque &&other) {
+  Deque& operator =(Deque&& other) {
     zap();
     buffer_ = other.buffer_;
     maxlength_ = other.maxlength_;
@@ -80,7 +80,7 @@ class Deque : private AllocPolicy
   }
 
   template <typename U>
-  bool append(U &&other) {
+  bool append(U&& other) {
     size_t next = ensureCanAppend();
     if (next == kInvalidIndex)
       return false;
@@ -90,7 +90,7 @@ class Deque : private AllocPolicy
   }
 
   template <typename U>
-  bool prepend(U &&other) {
+  bool prepend(U&& other) {
     size_t prev = ensureCanPrepend();
     if (prev == kInvalidIndex)
       return false;
@@ -127,21 +127,21 @@ class Deque : private AllocPolicy
     return t;
   }
 
-  const T &front() const {
+  const T& front() const {
     assert(!empty());
     return buffer_[first_];
   }
-  T &front() {
+  T& front() {
     assert(!empty());
     return buffer_[first_];
   }
-  const T &back() const {
+  const T& back() const {
     assert(!empty());
     if (last_ == 0)
       return buffer_[maxlength_ - 1];
     return buffer_[last_ - 1];
   }
-  T &back() {
+  T& back() {
     assert(!empty());
     if (last_ == 0)
       return buffer_[maxlength_ - 1];
@@ -160,8 +160,8 @@ class Deque : private AllocPolicy
   }
 
  private:
-  Deque(const Deque &other) = delete;
-  Deque &operator =(const Deque &other) = delete;
+  Deque(const Deque& other) = delete;
+  Deque& operator =(const Deque& other) = delete;
 
   // Return the next value of first_.
   size_t ensureCanPrepend() {
@@ -203,7 +203,7 @@ class Deque : private AllocPolicy
     }
 
     size_t new_maxlength = maxlength_ ? maxlength_ * 2 : 8;
-    T *new_buffer = (T *)this->am_malloc(sizeof(T) * new_maxlength);
+    T* new_buffer = (T*)this->am_malloc(sizeof(T) * new_maxlength);
     if (!new_buffer)
       return false;
 
@@ -247,7 +247,7 @@ class Deque : private AllocPolicy
   }
 
  private:
-  T *buffer_;
+  T* buffer_;
   size_t maxlength_;
 
   // Always points to the first readable item.

--- a/amtl/am-enum.h
+++ b/amtl/am-enum.h
@@ -45,32 +45,32 @@ namespace ke {
 } // namespace ke
 
 #define KE_DEFINE_ENUM_OPERATORS(EnumName)                                          \
-  static inline EnumName operator |(const EnumName &left, const EnumName &right) {  \
+  static inline EnumName operator |(const EnumName& left, const EnumName& right) {  \
     typedef ke::enum_integral_type<EnumName>::type int_type;                        \
     return EnumName(int_type(left) | int_type(right));                              \
   }                                                                                 \
-  static inline EnumName operator &(const EnumName &left, const EnumName &right) {  \
+  static inline EnumName operator&(const EnumName& left, const EnumName& right) {  \
     typedef ke::enum_integral_type<EnumName>::type int_type;                        \
     return EnumName(int_type(left) & int_type(right));                              \
   }                                                                                 \
-  static inline EnumName operator ^(const EnumName &left, const EnumName &right) {  \
+  static inline EnumName operator ^(const EnumName& left, const EnumName& right) {  \
     typedef ke::enum_integral_type<EnumName>::type int_type;                        \
     return EnumName(int_type(left) ^ int_type(right));                              \
   }                                                                                 \
-  static inline EnumName operator ~(const EnumName &flags) {                        \
+  static inline EnumName operator ~(const EnumName& flags) {                        \
     typedef ke::enum_integral_type<EnumName>::type int_type;                        \
     return EnumName(~int_type(flags));                                              \
   }                                                                                 \
-  static inline EnumName & operator |=(EnumName &left, const EnumName &right) {     \
+  static inline EnumName & operator |=(EnumName& left, const EnumName& right) {     \
     return left = left | right;                                                     \
   }                                                                                 \
-  static inline EnumName & operator &=(EnumName &left, const EnumName &right) {     \
+  static inline EnumName & operator &=(EnumName& left, const EnumName& right) {     \
     return left = left & right;                                                     \
   }                                                                                 \
-  static inline EnumName & operator ^=(EnumName &left, const EnumName &right) {     \
+  static inline EnumName & operator ^=(EnumName& left, const EnumName& right) {     \
     return left = left ^ right;                                                     \
   }                                                                                 \
-  static inline bool operator !(const EnumName &obj) {                              \
+  static inline bool operator !(const EnumName& obj) {                              \
     typedef ke::enum_integral_type<EnumName>::type int_type;                        \
     return int_type(obj) == 0;                                                      \
   }

--- a/amtl/am-fixedarray.h
+++ b/amtl/am-fixedarray.h
@@ -40,7 +40,7 @@ class FixedArray : private AllocPolicy
  public:
   FixedArray(size_t length, AllocPolicy = AllocPolicy()) {
     length_ = length;
-    data_ = (T *)this->am_malloc(sizeof(T) * length_);
+    data_ = (T*)this->am_malloc(sizeof(T) * length_);
     if (!data_)
       return;
 
@@ -61,40 +61,40 @@ class FixedArray : private AllocPolicy
   size_t length() const {
     return length_;
   }
-  T &operator [](size_t index) {
+  T& operator [](size_t index) {
     return at(index);
   }
-  const T &operator [](size_t index) const {
+  const T& operator [](size_t index) const {
     return at(index);
   }
-  T &at(size_t index) {
+  T& at(size_t index) {
     assert(index < length());
     return data_[index];
   }
-  const T &at(size_t index) const {
+  const T& at(size_t index) const {
     assert(index < length());
     return data_[index];
   }
-  T &back() {
+  T& back() {
     assert(length() > 0);
     return data_[length() - 1];
   }
-  const T &back() const {
+  const T& back() const {
     assert(length() > 0);
     return data_[length() - 1];
   }
 
-  T *buffer() const {
+  T* buffer() const {
     return data_;
   }
 
  private:
-  FixedArray(const FixedArray &other) = delete;
-  FixedArray &operator =(const FixedArray &other) = delete;
+  FixedArray(const FixedArray& other) = delete;
+  FixedArray& operator =(const FixedArray& other) = delete;
 
  private:
   size_t length_;
-  T *data_;
+  T* data_;
 };
 
 } // namespace ke

--- a/amtl/am-flags.h
+++ b/amtl/am-flags.h
@@ -81,7 +81,7 @@ public:
   Flags operator |(const Flags& other) const {
     return Flags(static_cast<T>(bits() | other.bits()));
   }
-  Flags operator &(const Flags& other) const {
+  Flags operator&(const Flags& other) const {
     return Flags(static_cast<T>(bits() & other.bits()));
   }
   Flags operator ^(const Flags& other) const {

--- a/amtl/am-function.h
+++ b/amtl/am-function.h
@@ -133,7 +133,7 @@ class Function<ReturnType(ArgTypes...)>
   }
 
   bool usingInlineStorage() const {
-    return (void *)impl_ == &buffer_;
+    return (void*)impl_ == &buffer_;
   }
 
  private:
@@ -306,7 +306,7 @@ class Lambda<ReturnType(ArgTypes...)>
   }
 
   bool usingInlineStorage() const {
-    return (void *)impl_ == &buffer_;
+    return (void*)impl_ == &buffer_;
   }
 
  private:
@@ -427,14 +427,14 @@ class FuncPtr<ReturnType(ArgTypes...)>
   void assignStatic(ReturnType(*fn)(ArgTypes...)) {
     typedef decltype(fn) FnType;
     ptr_ = reinterpret_cast<void*>(fn);
-    invoker_ = [](void *ptr, ArgTypes&&... argv) {
+    invoker_ = [](void* ptr, ArgTypes&&... argv) {
       return (reinterpret_cast<FnType>(ptr))(ke::Forward<ArgTypes>(argv)...);
     };
   }
   template <typename T>
   void assignFunctor(T* obj) {
     ptr_ = obj;
-    invoker_ = [](void *ptr, ArgTypes&&... argv) {
+    invoker_ = [](void* ptr, ArgTypes&&... argv) {
       return (reinterpret_cast<T*>(ptr))->operator()(ke::Forward<ArgTypes>(argv)...);
     };
   }

--- a/amtl/am-hashmap.h
+++ b/amtl/am-hashmap.h
@@ -39,8 +39,8 @@ namespace ke {
 // K - Key type.
 // V - Value type.
 // HashPolicy - A struct with a hash and comparator function for each lookup type:
-//     static uint32_t hash(const Type &value);
-//     static bool matches(const Type &value, const K &key);
+//     static uint32_t hash(const Type& value);
+//     static bool matches(const Type& value, const K& key);
 //
 // All types that match a given key, must compute the same hash.
 //
@@ -59,17 +59,17 @@ class HashMap : private AllocPolicy
 
     Entry()
     {}
-    Entry(const Entry &other)
+    Entry(const Entry& other)
       : key(other.key),
         value(other.value)
     {}
-    Entry(Entry &&other)
+    Entry(Entry&& other)
       : key(ke::Move(other.key)),
         value(ke::Move(other.value))
     {}
 
     template <typename UK, typename UV>
-    Entry(UK &&aKey, UV &&aValue)
+    Entry(UK&& aKey, UV&& aValue)
      : key(ke::Forward<UK>(aKey)),
        value(ke::Forward<UV>(aValue))
     { }
@@ -80,12 +80,12 @@ class HashMap : private AllocPolicy
     typedef Entry Payload;
 
     template <typename Lookup>
-    static uint32_t hash(const Lookup &key) {
+    static uint32_t hash(const Lookup& key) {
       return HashPolicy::hash(key);
     }
 
     template <typename Lookup>
-    static bool matches(const Lookup &key, const Payload &payload) {
+    static bool matches(const Lookup& key, const Payload& payload) {
       return HashPolicy::matches(key, payload.key);
     }
   };
@@ -113,33 +113,33 @@ class HashMap : private AllocPolicy
   typedef typename Internal::iterator iterator;
 
   template <typename Lookup>
-  Result find(const Lookup &key) const {
+  Result find(const Lookup& key) const {
     return table_.find(key);
   }
 
   template <typename Lookup>
-  Insert findForAdd(const Lookup &key) {
+  Insert findForAdd(const Lookup& key) {
     return table_.findForAdd(key);
   }
 
   template <typename Lookup>
-  void removeIfExists(const Lookup &key) {
+  void removeIfExists(const Lookup& key) {
     return table_.removeIfExists(key);
   }
 
-  void remove(Result &r) {
+  void remove(Result& r) {
     table_.remove(r);
   }
 
   // The map must not have been mutated in between findForAdd() and add().
   // The Insert object is still valid after add() returns, however.
   template <typename UK, typename UV>
-  bool add(Insert &i, UK &&key, UV &&value) {
+  bool add(Insert& i, UK&& key, UV&& value) {
     Entry entry(ke::Forward<UK>(key), ke::Forward<UV>(value));
     return table_.add(i, ke::Move(entry));
   }
   template <typename UK>
-  bool add(Insert &i, UK &&key) {
+  bool add(Insert& i, UK&& key) {
     Entry entry(ke::Forward<UK>(key), V());
     return table_.add(i, ke::Move(entry));
   }
@@ -147,7 +147,7 @@ class HashMap : private AllocPolicy
   // This can be used to avoid compiler constructed temporaries, since AMTL
   // does not yet support move semantics. If you use this, the key and value
   // must be set after.
-  bool add(Insert &i) {
+  bool add(Insert& i) {
     return table_.add(i);
   }
 
@@ -181,10 +181,10 @@ class HashMap : private AllocPolicy
 template <typename T>
 struct PointerPolicy
 {
-  static inline uint32_t hash(T *p) {
+  static inline uint32_t hash(T* p) {
     return HashPointer(p);
   }
-  static inline bool matches(T *p1, T *p2) {
+  static inline bool matches(T* p1, T* p2) {
     return p1 == p2;
   }
 };

--- a/amtl/am-hashset.h
+++ b/amtl/am-hashset.h
@@ -38,8 +38,8 @@ namespace ke {
 //
 // K - Key type.
 // HashPolicy - A struct with a hash and comparator function for each lookup type:
-//    static uint32_t hash(const Type &value);
-//    static bool matches(const Type &value, const K &key);
+//    static uint32_t hash(const Type& value);
+//    static bool matches(const Type& value, const K& key);
 //
 // Like HashMap and HashTable, init() must be called to construct the set.
 template <typename K,
@@ -51,12 +51,12 @@ class HashSet : private AllocPolicy
     typedef K Payload;
 
     template <typename Lookup>
-    static uint32_t hash(const Lookup &key) {
+    static uint32_t hash(const Lookup& key) {
       return HashPolicy::hash(key);
     }
 
     template <typename Lookup>
-    static bool matches(const Lookup &key, const Payload &payload) {
+    static bool matches(const Lookup& key, const Payload& payload) {
       return HashPolicy::matches(key, payload);
     }
   };
@@ -84,35 +84,35 @@ class HashSet : private AllocPolicy
   typedef typename Internal::iterator iterator;
 
   template <typename Lookup>
-  Result find(const Lookup &key) {
+  Result find(const Lookup& key) {
     return table_.find(key);
   }
 
   template <typename Lookup>
-  Insert findForAdd(const Lookup &key) {
+  Insert findForAdd(const Lookup& key) {
     return table_.findForAdd(key);
   }
 
   template <typename Lookup>
-  void removeIfExists(const Lookup &key) {
+  void removeIfExists(const Lookup& key) {
     return table_.removeIfExists(key);
   }
 
-  void remove(Result &r) {
+  void remove(Result& r) {
     table_.remove(r);
   }
 
   // The map must not have been mutated in between findForAdd() and add().
   // The Insert object is still valid after add() returns, however.
   template <typename UK>
-  bool add(Insert &i, UK &&key) {
+  bool add(Insert& i, UK&& key) {
     return table_.add(i, ke::Forward<UK>(key));
   }
 
   // This can be used to avoid compiler constructed temporaries, since AMTL
   // does not yet support move semantics. If you use this, the key and value
   // must be set after.
-  bool add(Insert &i) {
+  bool add(Insert& i) {
     return table_.add(i);
   }
 
@@ -133,7 +133,7 @@ class HashSet : private AllocPolicy
 
   // Convenience wrapper for find().found().
   template <typename Lookup>
-  bool has(const Lookup &key) {
+  bool has(const Lookup& key) {
     Result r = table_.find(key);
     return r.found();
   }
@@ -141,7 +141,7 @@ class HashSet : private AllocPolicy
   // Convenience wrapper for findForAdd() + add(), if the item is not already
   // in the set.
   template <typename UK>
-  void add(UK &&key) {
+  void add(UK&& key) {
     Insert p = table_.findForAdd(key);
     if (!p.found())
       table_.add(p, ke::Forward<UK>(key));

--- a/amtl/am-inlinelist.h
+++ b/amtl/am-inlinelist.h
@@ -52,7 +52,7 @@ class InlineListNode
   {
   }
 
-  InlineListNode(InlineListNode *next, InlineListNode *prev)
+  InlineListNode(InlineListNode* next, InlineListNode* prev)
    : next_(next),
      prev_(prev)
   {
@@ -71,8 +71,8 @@ class InlineListNode
   }
 
  protected:
-  InlineListNode *next_;
-  InlineListNode *prev_;
+  InlineListNode* next_;
+  InlineListNode* prev_;
 };
 
 // An InlineList is a linked list that threads link pointers through objects,
@@ -91,7 +91,7 @@ class InlineList
   Node head_;
 
   // Work around a clang bug where we can't initialize with &head_ in the ctor.
-  inline Node *head() {
+  inline Node* head() {
     return &head_;
   }
 
@@ -114,10 +114,10 @@ class InlineList
   class iterator
   {
     friend class InlineList;
-    Node *iter_;
+    Node* iter_;
 
    public:
-    iterator(Node *iter)
+    iterator(Node* iter)
       : iter_(iter)
     {
     }
@@ -131,16 +131,16 @@ class InlineList
       iter_ = iter_->next_;
       return old;
     }
-    T * operator *() {
-      return static_cast<T *>(iter_);
+    T * operator*() {
+      return static_cast<T*>(iter_);
     }
     T * operator ->() {
-      return static_cast<T *>(iter_);
+      return static_cast<T*>(iter_);
     }
-    bool operator !=(const iterator &where) const {
+    bool operator !=(const iterator& where) const {
       return iter_ != where.iter_;
     }
-    bool operator ==(const iterator &where) const {
+    bool operator ==(const iterator& where) const {
       return iter_ == where.iter_;
     }
   };
@@ -153,7 +153,7 @@ class InlineList
     return iterator(&head_);
   }
 
-  iterator erase(iterator &at) {
+  iterator erase(iterator& at) {
     iterator next = at;
     next++;
 
@@ -169,7 +169,7 @@ class InlineList
     return head_.next_ == &head_;
   }
 
-  void remove(Node *t) {
+  void remove(Node* t) {
     t->prev_->next_ = t->next_;
     t->next_->prev_ = t->prev_;
 
@@ -179,7 +179,7 @@ class InlineList
 #endif
   }
 
-  void append(Node *t) {
+  void append(Node* t) {
     assert(!t->next_);
     assert(!t->prev_);
 

--- a/amtl/am-linkedlist.h
+++ b/amtl/am-linkedlist.h
@@ -55,8 +55,8 @@ class LinkedList : private AllocPolicy
   struct Node
   {
     T obj;
-    Node *next;
-    Node *prev;
+    Node* next;
+    Node* prev;
   };
 
 public:
@@ -71,12 +71,12 @@ public:
   }
 
   template <typename U>
-  bool append(U &&obj) {
+  bool append(U&& obj) {
     return insertBefore(end(), ke::Forward<U>(obj)) != end();
   }
 
   template <typename U>
-  bool prepend(U &&obj) {
+  bool prepend(U&& obj) {
     return insertBefore(begin(), ke::Forward<U>(obj)) != begin();
   }
 
@@ -92,8 +92,8 @@ public:
   }
 
   void clear() {
-    Node *node = head()->next;
-    Node *temp;
+    Node* node = head()->next;
+    Node* temp;
     head()->next = head();
     head()->prev = head();
 
@@ -110,33 +110,33 @@ public:
     return (length_ == 0);
   }
 
-  T &front() {
+  T& front() {
     assert(!empty());
     return head()->next->obj;
   }
-  T &back() {
+  T& back() {
     assert(!empty());
     return head()->prev->obj;
   }
 
  private:
-  const Node *head() const {
+  const Node* head() const {
     return sentinel_.address();
   }
-  Node *head() {
+  Node* head() {
     return sentinel_.address();
   }
 
   template <typename U>
-  Node *allocNode(U &&obj) {
-    Node *node = (Node *)this->am_malloc(sizeof(Node));
+  Node* allocNode(U&& obj) {
+    Node* node = (Node*)this->am_malloc(sizeof(Node));
     if (!node)
       return nullptr;
     new (&node->obj) T(ke::Forward<U>(obj));
     return node;
   }
 
-  void freeNode(Node *node) {
+  void freeNode(Node* node) {
     node->obj.~T();
     this->am_free(node);
   }
@@ -155,20 +155,20 @@ public:
      : this_(nullptr)
     {
     }
-    iterator(const LinkedList &src)
+    iterator(const LinkedList& src)
      : this_(src.head())
     {
     }
-    iterator(Node *n)
+    iterator(Node* n)
      : this_(n)
     {
     }
-    iterator(const iterator &where)
+    iterator(const iterator& where)
      : this_(where.this_)
     {
     }
 
-    iterator &operator --() {
+    iterator& operator --() {
       if (this_)
         this_ = this_->prev;
       return *this;
@@ -179,7 +179,7 @@ public:
         this_ = this_->prev;
       return old;
     }  
-    iterator &operator ++() {
+    iterator& operator ++() {
       if (this_)
         this_ = this_->next;
       return *this;
@@ -191,23 +191,23 @@ public:
       return old;
     }
     
-    const T &operator * () const {
+    const T& operator * () const {
       return this_->obj;
     }
-    T &operator * () {
+    T& operator * () {
       return this_->obj;
     }
-    T *operator ->() {
+    T* operator ->() {
       return &this_->obj;
     }
-    const T *operator ->() const {
+    const T* operator ->() const {
       return &(this_->obj);
     }
     
-    bool operator !=(const iterator &where) const {
+    bool operator !=(const iterator& where) const {
       return (this_ != where.this_);
     }
-    bool operator ==(const iterator &where) const {
+    bool operator ==(const iterator& where) const {
       return (this_ == where.this_);
     }
 
@@ -216,16 +216,16 @@ public:
     }
 
    private:
-    Node *this_;
+    Node* this_;
   };
 
  private:
   // Insert obj right before where.
-  iterator insert(iterator where, Node *node) {
+  iterator insert(iterator where, Node* node) {
     if (!node)
       return where;
 
-    Node *pWhereNode = where.this_;
+    Node* pWhereNode = where.this_;
     
     pWhereNode->prev->next = node;
     node->prev = pWhereNode->prev;
@@ -244,7 +244,7 @@ public:
     return iterator(head());
   }
   iterator erase(iterator where) {
-    Node *pNode = where.this_;
+    Node* pNode = where.this_;
     iterator iter(where);
     iter++;
 
@@ -257,13 +257,13 @@ public:
     return iter;
   }
   template <typename U>
-  iterator insertBefore(iterator where, U &&obj) {
+  iterator insertBefore(iterator where, U&& obj) {
     return insert(where, allocNode(ke::Forward<U>(obj)));
   }
 
  public:
   // Removes one instance of |obj| from the list, if found.
-  void remove(const T &obj) {
+  void remove(const T& obj) {
     for (iterator b = begin(); b != end(); b++) {
       if (*b == obj) {
         erase(b);
@@ -273,7 +273,7 @@ public:
   }
 
   template <typename U>
-  iterator find(const U &equ) {
+  iterator find(const U& equ) {
     for (iterator iter = begin(); iter != end(); iter++) {
       if (*iter == equ)
         return iter;
@@ -285,8 +285,8 @@ public:
  private:
   // These are disallowed because they basically violate the failure handling
   // model for AllocPolicies and are also likely to have abysmal performance.
-  LinkedList &operator =(const LinkedList &other) = delete;
-  LinkedList(const LinkedList &other) = delete;
+  LinkedList& operator =(const LinkedList& other) = delete;
+  LinkedList(const LinkedList& other) = delete;
 };
 
 } // namespace ke

--- a/amtl/am-maybe.h
+++ b/amtl/am-maybe.h
@@ -81,7 +81,7 @@ class Maybe
     assert(isValid());
     return t_.address();
   }
-  T& operator *() {
+  T& operator*() {
     assert(isValid());
     return *t_.address();
   }
@@ -89,7 +89,7 @@ class Maybe
     assert(isValid());
     return t_.address();
   }
-  const T& operator *() const {
+  const T& operator*() const {
     assert(isValid());
     return *t_.address();
   }

--- a/amtl/am-moveable.h
+++ b/amtl/am-moveable.h
@@ -38,9 +38,9 @@ namespace ke {
 // C++11, we implement this as STL does for std::move.
 template <typename T>
 static inline typename remove_reference<T>::type &&
-Move(T &&t)
+Move(T&& t)
 {
-  return static_cast<typename remove_reference<T>::type &&>(t);
+  return static_cast<typename remove_reference<T>::type&&>(t);
 }
 
 // std::forward replacement. See:
@@ -48,21 +48,21 @@ Move(T &&t)
 //   http://thbecker.net/articles/rvalue_references/section_08.html
 template <typename T>
 static KE_CONSTEXPR inline T &&
-Forward(typename remove_reference<T>::type &t) KE_NOEXCEPT
+Forward(typename remove_reference<T>::type& t) KE_NOEXCEPT
 {
-  return static_cast<T &&>(t);
+  return static_cast<T&&>(t);
 }
 
 template <typename T>
 static KE_CONSTEXPR inline T &&
-Forward(typename remove_reference<T>::type &&t) KE_NOEXCEPT
+Forward(typename remove_reference<T>::type&& t) KE_NOEXCEPT
 {
-  return static_cast<T &&>(t);
+  return static_cast<T&&>(t);
 }
 
 template <typename T>
 static inline void
-MoveRange(T *dest, T *src, size_t length)
+MoveRange(T* dest, T* src, size_t length)
 {
   for (size_t i = 0; i < length; i++) {
     new (&dest[i]) T(ke::Move(src[i]));

--- a/amtl/am-raii.h
+++ b/amtl/am-raii.h
@@ -36,7 +36,7 @@ template <typename T>
 class SaveAndSet
 {
  public:
-  SaveAndSet(T *location, const T &value)
+  SaveAndSet(T* location, const T& value)
    : location_(location),
      old_(*location)
   {
@@ -47,7 +47,7 @@ class SaveAndSet
   }
 
  private:
-  T *location_;
+  T* location_;
   T old_;
 };
 
@@ -55,11 +55,11 @@ template <typename T>
 class StackLinked
 {
  public:
-  StackLinked<T>(T **prevp)
+  StackLinked<T>(T** prevp)
    : prevp_(prevp),
      prev_(*prevp)
   {
-    *prevp_ = static_cast<T *>(this);
+    *prevp_ = static_cast<T*>(this);
   }
   virtual ~StackLinked() {
     assert(*prevp_ == this);
@@ -67,12 +67,12 @@ class StackLinked
   }
 
  protected:
-  T **prevp_;
-  T *prev_;
+  T** prevp_;
+  T* prev_;
 };
 
 template <typename T> T
-ReturnAndVoid(T &t)
+ReturnAndVoid(T& t)
 {
     T saved = t;
     t = T();

--- a/amtl/am-refcounting-threadsafe.h
+++ b/amtl/am-refcounting-threadsafe.h
@@ -53,7 +53,7 @@ class RefcountedThreadsafe
     }
     bool Release() {
         if (!refcount_.decrement()) {
-            delete static_cast<T *>(this);
+            delete static_cast<T*>(this);
             return false;
         }
         return true;
@@ -118,7 +118,7 @@ class VirtualRefcountedThreadsafe : public IRefcounted
 // destroy the left-hand side. This prevents such a scenario by making reads
 // atomic with respect to the incref operation.
 //
-// Pointers stored in an AtomicRef<> must be at least sizeof(void *) aligned.
+// Pointers stored in an AtomicRef<> must be at least sizeof(void*) aligned.
 template <typename T>
 class AtomicRef
 {
@@ -126,22 +126,22 @@ class AtomicRef
   AtomicRef()
    : thing_(nullptr)
   {}
-  AtomicRef(T *thing)
+  AtomicRef(T* thing)
    : thing_(thing)
   {
-    assert(IsAligned(thing, sizeof(void *)));
+    assert(IsAligned(thing, sizeof(void*)));
     if (thing)
       thing->AddRef();
   }
   ~AtomicRef() {
     assert(thing_ == untagged(thing_));
     if (thing_)
-      reinterpret_cast<T *>(thing_)->Release();
+      reinterpret_cast<T*>(thing_)->Release();
   }
 
   // Atomically retrieve and add a reference to the contained value.
   AlreadyRefed<T> get() {
-    T *value = lock();
+    T* value = lock();
     if (value)
       value->AddRef();
     unlock(value);
@@ -149,8 +149,8 @@ class AtomicRef
   }
 
   // Atomically incref the new value and replace the old value.
-  void operator =(T *other) {
-    T *value = lock();
+  void operator =(T* other) {
+    T* value = lock();
     if (other)
       other->AddRef();
     unlock(other);
@@ -159,28 +159,28 @@ class AtomicRef
   }
 
  private:
-  AtomicRef(const AtomicRef &other) = delete;
-  void operator =(const AtomicRef &other) = delete;
+  AtomicRef(const AtomicRef& other) = delete;
+  void operator =(const AtomicRef& other) = delete;
 
  private:
   // We represent a locked state with a tag bit.
-  void *tagged(void *ptr) {
-    return reinterpret_cast<void *>(uintptr_t(ptr) | 1);
+  void* tagged(void* ptr) {
+    return reinterpret_cast<void*>(uintptr_t(ptr) | 1);
   }
-  void *untagged(void *ptr) {
-    return reinterpret_cast<void *>(uintptr_t(ptr) & ~uintptr_t(1));
+  void* untagged(void* ptr) {
+    return reinterpret_cast<void*>(uintptr_t(ptr) & ~uintptr_t(1));
   }
 
-  T *lock() {
+  T* lock() {
     // Spin until we can replace an untagged ptr with the tagged version.
-    void *oldval = untagged(thing_);
+    void* oldval = untagged(thing_);
     while (CompareAndSwapPtr(&thing_, tagged(oldval), oldval) != oldval) {
       YieldProcessor();
       oldval = untagged(thing_);
     }
-    return reinterpret_cast<T *>(oldval);
+    return reinterpret_cast<T*>(oldval);
   }
-  void unlock(T *ptr) {
+  void unlock(T* ptr) {
     // Nothing should have mutated the value, and the new value should be
     // untagged.
     assert(thing_ == tagged(thing_));

--- a/amtl/am-refcounting.h
+++ b/amtl/am-refcounting.h
@@ -58,11 +58,11 @@ class AlreadyRefed
       : thing_(nullptr)
     {
     }
-    explicit AlreadyRefed(T *t)
+    explicit AlreadyRefed(T* t)
       : thing_(t)
     {
     }
-    AlreadyRefed(const AlreadyRefed<T> &other)
+    AlreadyRefed(const AlreadyRefed<T>& other)
       : thing_(other.thing_)
     {
         if (thing_)
@@ -81,28 +81,28 @@ class AlreadyRefed
     bool operator !() const {
         return !thing_;
     }
-    T *operator ->() const {
+    T* operator ->() const {
         return thing_;
     }
-    bool operator ==(T *other) const {
+    bool operator ==(T* other) const {
         return thing_ == other;
     }
-    bool operator !=(T *other) const {
+    bool operator !=(T* other) const {
         return thing_ != other;
     }
 
     // Analagous to AutoPtr::take().
-    T *take() const {
+    T* take() const {
         return ReturnAndVoid(thing_);
     }
 
   private:
-    mutable T *thing_;
+    mutable T* thing_;
 };
 
 template <typename T>
 static inline AlreadyRefed<T>
-AdoptRef(T *t)
+AdoptRef(T* t)
 {
     return AlreadyRefed<T>(t);
 }
@@ -127,7 +127,7 @@ class Refcounted
     void Release() {
         assert(refcount_ > 0);
         if (--refcount_ == 0)
-            delete static_cast<T *>(this);
+            delete static_cast<T*>(this);
     }
 
   protected:
@@ -195,7 +195,7 @@ template <typename T>
 class RefPtr
 {
   public:
-    RefPtr(T *thing)
+    RefPtr(T* thing)
       : thing_(thing)
     {
         AddRef();
@@ -206,18 +206,18 @@ class RefPtr
     {
     }
 
-    RefPtr(const RefPtr &other)
+    RefPtr(const RefPtr& other)
       : thing_(other.thing_)
     {
         AddRef();
     }
-    RefPtr(RefPtr &&other)
+    RefPtr(RefPtr&& other)
       : thing_(other.thing_)
     {
         other.thing_ = nullptr;
     }
     template <typename S>
-    RefPtr(const RefPtr<S> &other)
+    RefPtr(const RefPtr<S>& other)
       : thing_(*other)
     {
         AddRef();
@@ -227,12 +227,12 @@ class RefPtr
       : thing_(other.forget().take())
     {
     }
-    RefPtr(const AlreadyRefed<T> &other)
+    RefPtr(const AlreadyRefed<T>& other)
       : thing_(other.take())
     {
     }
     template <typename S>
-    RefPtr(const AlreadyRefed<S> &other)
+    RefPtr(const AlreadyRefed<S>& other)
       : thing_(other.take())
     {
     }
@@ -241,22 +241,22 @@ class RefPtr
         Release();
     }
 
-    T *operator ->() const {
-        return operator *();
+    T* operator ->() const {
+        return operator*();
     }
-    T *operator *() const {
+    T* operator*() const {
         return thing_;
     }
-    operator T *() {
+    operator T*() {
         return thing_;
     }
-    operator T *() const {
+    operator T*() const {
         return thing_;
     }
     bool operator !() const {
         return !thing_;
     }
-    operator T &() {
+    operator T&() {
         return *thing_;
     }
     explicit operator bool() const {
@@ -271,7 +271,7 @@ class RefPtr
     }
 
     template <typename S>
-    RefPtr &operator =(S *thing) {
+    RefPtr& operator =(S* thing) {
         Release();
         thing_ = thing;
         AddRef();
@@ -279,37 +279,37 @@ class RefPtr
     }
     
     template <typename S>
-    RefPtr &operator =(const AlreadyRefed<S> &other) {
+    RefPtr& operator =(const AlreadyRefed<S>& other) {
         Release();
         thing_ = other.take();
         return *this;
     }
 
-    RefPtr &operator =(const RefPtr &other) {
+    RefPtr& operator =(const RefPtr& other) {
         Release();
         thing_ = other.thing_;
         AddRef();
         return *this;
     }
 
-    RefPtr &operator =(RefPtr &&other) {
+    RefPtr& operator =(RefPtr&& other) {
         Release();
         thing_ = other.thing_;
         other.thing_ = nullptr;
         return *this;
     }
 
-    T *get() const {
+    T* get() const {
         return thing_;
     }
-    T **byref() {
+    T** byref() {
         return &thing_;
     }
-    T * const *byref_const() const {
+    T * const* byref_const() const {
         return &thing_;
     }
-    void **address() {
-        return reinterpret_cast<void **>(&thing_);
+    void** address() {
+        return reinterpret_cast<void**>(&thing_);
     }
 
   private:
@@ -323,7 +323,7 @@ class RefPtr
     }
 
   protected:
-    T *thing_;
+    T* thing_;
 };
 
 } // namespace ke

--- a/amtl/am-storagebuffer.h
+++ b/amtl/am-storagebuffer.h
@@ -40,11 +40,11 @@ template <typename T>
 class StorageBuffer
 {
  public:
-  T *address() {
-    return reinterpret_cast<T *>(buffer_);
+  T* address() {
+    return reinterpret_cast<T*>(buffer_);
   }
-  const T *address() const {
-    return reinterpret_cast<const T *>(buffer_);
+  const T* address() const {
+    return reinterpret_cast<const T*>(buffer_);
   }
 
  private:

--- a/amtl/am-string.h
+++ b/amtl/am-string.h
@@ -69,7 +69,7 @@ class AString
   {
   }
 
-  explicit AString(const char *str) {
+  explicit AString(const char* str) {
     if (str && str[0]) {
       set(str, strlen(str));
     } else {
@@ -77,10 +77,10 @@ class AString
       length_ = 0;
     }
   }
-  AString(const char *str, size_t length) {
+  AString(const char* str, size_t length) {
     set(str, length);
   }
-  AString(const AString &other) {
+  AString(const AString& other) {
     if (other.length_)
       set(other.chars_.get(), other.length_);
     else
@@ -90,14 +90,14 @@ class AString
    : chars_(Move(ptr)),
      length_(length)
   {}
-  AString(AString &&other)
+  AString(AString&& other)
    : chars_(Move(other.chars_)),
      length_(other.length_)
   {
     other.length_ = 0;
   }
 
-  AString &operator =(const char *str) {
+  AString& operator =(const char* str) {
     if (str && str[0]) {
       set(str, strlen(str));
     } else {
@@ -106,7 +106,7 @@ class AString
     }
     return *this;
   }
-  AString &operator =(const AString &other) {
+  AString& operator =(const AString& other) {
     if (other.length_) {
       set(other.chars_.get(), other.length_);
     } else {
@@ -115,20 +115,20 @@ class AString
     }
     return *this;
   }
-  AString &operator =(AString &&other) {
+  AString& operator =(AString&& other) {
     chars_ = Move(other.chars_);
     length_ = other.length_;
     other.length_ = 0;
     return *this;
   }
 
-  int compare(const char *str) const {
+  int compare(const char* str) const {
     return strcmp(chars(), str);
   }
-  int compare(const AString &other) const {
+  int compare(const AString& other) const {
     return strcmp(chars(), other.chars());
   }
-  bool operator ==(const AString &other) const {
+  bool operator ==(const AString& other) const {
     return other.length() == length() &&
            memcmp(other.chars(), chars(), length()) == 0;
   }
@@ -156,7 +156,7 @@ class AString
   size_t length() const {
     return length_;
   }
-  const char *chars() const {
+  const char* chars() const {
     if (!chars_)
       return "";
     return chars_.get();
@@ -180,7 +180,7 @@ class AString
  private:
   static const size_t kInvalidLength = (size_t)-1;
 
-  void set(const char *str, size_t length) {
+  void set(const char* str, size_t length) {
     chars_ = MakeUnique<char[]>(length + 1);
     length_ = length;
     memcpy(chars_.get(), str, length);
@@ -201,8 +201,8 @@ class AString
 // Forward declare these functions since GCC will complain otherwise.
 static inline UniquePtr<char[]> SprintfArgs(const char* fmt, va_list ap) KE_PRINTF_FUNCTION(1, 0);
 static inline UniquePtr<char[]> Sprintf(const char* fmt, ...) KE_PRINTF_FUNCTION(1, 2);
-static inline size_t SafeVsprintf(char *buffer, size_t maxlength, const char *fmt, va_list ap) KE_PRINTF_FUNCTION(3, 0);
-static inline size_t SafeSprintf(char *buffer, size_t maxlength, const char *fmt, ...) KE_PRINTF_FUNCTION(3, 4);
+static inline size_t SafeVsprintf(char* buffer, size_t maxlength, const char* fmt, va_list ap) KE_PRINTF_FUNCTION(3, 0);
+static inline size_t SafeSprintf(char* buffer, size_t maxlength, const char* fmt, ...) KE_PRINTF_FUNCTION(3, 4);
 
 namespace detail {
 
@@ -313,7 +313,7 @@ AString::format(const char* fmt, ...)
 }
 
 static inline size_t
-SafeVsprintf(char *buffer, size_t maxlength, const char *fmt, va_list ap)
+SafeVsprintf(char* buffer, size_t maxlength, const char* fmt, va_list ap)
 {
   if (!maxlength)
     return 0;
@@ -329,7 +329,7 @@ SafeVsprintf(char *buffer, size_t maxlength, const char *fmt, va_list ap)
 }
 
 static inline size_t
-SafeSprintf(char *buffer, size_t maxlength, const char *fmt, ...)
+SafeSprintf(char* buffer, size_t maxlength, const char* fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);

--- a/amtl/am-thread-posix.h
+++ b/amtl/am-thread-posix.h
@@ -70,7 +70,7 @@ class Mutex : public Lockable
     pthread_mutex_unlock(&mutex_);
   }
   
-  pthread_mutex_t *raw() {
+  pthread_mutex_t* raw() {
     return &mutex_;
   }
 
@@ -166,8 +166,8 @@ class Thread
     char name[17];
   };
  public:
-  Thread(ke::Function<void()>&& callback, const char *name = nullptr) {
-    ThreadData *data = new ThreadData;
+  Thread(ke::Function<void()>&& callback, const char* name = nullptr) {
+    ThreadData* data = new ThreadData;
     data->callback = ke::Move(callback);
     snprintf(data->name, sizeof(data->name), "%s", name ? name : "");
 
@@ -193,14 +193,14 @@ class Thread
   }
 
  private:
-  static void *Main(void *arg) {
-    AutoPtr<ThreadData> data((ThreadData *)arg);
+  static void* Main(void* arg) {
+    AutoPtr<ThreadData> data((ThreadData*)arg);
 
     if (data->name[0]) {
 #if defined(__linux__)
       prctl(PR_SET_NAME, (unsigned long)data->name);
 #elif defined(__APPLE__)
-      int (*fn)(const char *) = (int (*)(const char *))dlsym(RTLD_DEFAULT, "pthread_setname_np");
+      int (*fn)(const char*) = (int (*)(const char*))dlsym(RTLD_DEFAULT, "pthread_setname_np");
       if (fn)
         fn(data->name);
 #endif

--- a/amtl/am-thread-utils.h
+++ b/amtl/am-thread-utils.h
@@ -186,7 +186,7 @@ class Lockable
 class AutoLock
 {
  public:
-  AutoLock(Lockable *lock)
+  AutoLock(Lockable* lock)
    : lock_(lock)
   {
     lock_->Lock();
@@ -196,7 +196,7 @@ class AutoLock
   }
 
  private:
-  Lockable *lock_;
+  Lockable* lock_;
 };
 
 class AutoMaybeLock
@@ -204,7 +204,7 @@ class AutoMaybeLock
   friend class AutoMaybeUnlock;
 
  public:
-  AutoMaybeLock(Lockable *lock)
+  AutoMaybeLock(Lockable* lock)
    : lock_(lock)
   {
     if (lock_)
@@ -225,7 +225,7 @@ class AutoMaybeLock
   //     return helper(&lock);
   //   }
   //
-  // helper_while_locked(AutoMaybeLock *mlock) {
+  // helper_while_locked(AutoMaybeLock* mlock) {
   //   ...
   //   mlock->unlock();
   //   callback
@@ -241,13 +241,13 @@ class AutoMaybeLock
   }
 
  private:
-  Lockable *lock_;
+  Lockable* lock_;
 };
 
 class AutoMaybeUnlock
 {
  public:
-  AutoMaybeUnlock(Lockable *lock)
+  AutoMaybeUnlock(Lockable* lock)
    : lock_(lock)
   {
     if (lock_)
@@ -259,13 +259,13 @@ class AutoMaybeUnlock
   }
 
  private:
-  Lockable *lock_;
+  Lockable* lock_;
 };
 
 class AutoTryLock
 {
  public:
-  AutoTryLock(Lockable *lock) {
+  AutoTryLock(Lockable* lock) {
     lock_ = lock->TryLock() ? lock : nullptr;
   }
   ~AutoTryLock() {
@@ -278,14 +278,14 @@ class AutoTryLock
   }
 
  private:
-  Lockable *lock_;
+  Lockable* lock_;
 };
 
 // RAII for automatically unlocking and relocking an object.
 class AutoUnlock
 {
  public:
-  AutoUnlock(Lockable *lock)
+  AutoUnlock(Lockable* lock)
    : lock_(lock)
   {
     lock_->Unlock();
@@ -295,7 +295,7 @@ class AutoUnlock
   }
 
  private:
-  Lockable *lock_;
+  Lockable* lock_;
 };
 
 enum WaitResult {

--- a/amtl/am-thread-windows.h
+++ b/amtl/am-thread-windows.h
@@ -115,7 +115,7 @@ class ConditionVariable : public Lockable
 class Thread
 {
  public:
-  Thread(ke::Function<void()>&& callback, const char *name = nullptr) {
+  Thread(ke::Function<void()>&& callback, const char* name = nullptr) {
     auto ptr = new ke::Function<void()>(ke::Move(callback));
     thread_ = CreateThread(nullptr, 0, MainCallback, ptr, 0, nullptr);
     if (!thread_)

--- a/amtl/am-threadlocal.h
+++ b/amtl/am-threadlocal.h
@@ -60,11 +60,11 @@ template <typename T>
 class ThreadLocal
 {
  public:
-  void operator =(const T &other) {
+  void operator =(const T& other) {
     set(other);
   }
 
-  T operator *() const {
+  T operator*() const {
     return get();
   }
   T operator ->() const {
@@ -73,16 +73,16 @@ class ThreadLocal
   bool operator !() const {
     return !get();
   }
-  bool operator ==(const T &other) const {
+  bool operator ==(const T& other) const {
     return get() == other;
   }
-  bool operator !=(const T &other) const {
+  bool operator !=(const T& other) const {
     return get() != other;
   }
 
  private:
-  ThreadLocal(const ThreadLocal &other) = delete;
-  ThreadLocal &operator =(const ThreadLocal &other) = delete;
+  ThreadLocal(const ThreadLocal& other) = delete;
+  ThreadLocal& operator =(const ThreadLocal& other) = delete;
 
 #if !defined(KE_SINGLE_THREADED)
  private:
@@ -98,7 +98,7 @@ class ThreadLocal
       return T();
     return internalGet();
   }
-  void set(const T &t) {
+  void set(const T& t) {
     if (!allocated_ && !allocate()) {
       fprintf(stderr, "could not allocate thread-local storage\n");
       abort();
@@ -116,11 +116,11 @@ class ThreadLocal
   T internalGet() const {
     return reinterpret_cast<T>(TlsGetValue(key_));
   }
-  void internalSet(const T &t) {
+  void internalSet(const T& t) {
     TlsSetValue(key_, reinterpret_cast<LPVOID>(t));
   }
   bool allocate() {
-    if (InterlockedCompareExchange((volatile LONG *)&allocated_, 1, 0) == 1)
+    if (InterlockedCompareExchange((volatile LONG*)&allocated_, 1, 0) == 1)
       return true;
     key_ = TlsAlloc();
     return key_ != TLS_OUT_OF_INDEXES;
@@ -145,8 +145,8 @@ class ThreadLocal
   T internalGet() const {
     return (T)reinterpret_cast<uintptr_t>(pthread_getspecific(key_));
   }
-  void internalSet(const T &t) {
-    pthread_setspecific(key_, reinterpret_cast<void *>(t));
+  void internalSet(const T& t) {
+    pthread_setspecific(key_, reinterpret_cast<void*>(t));
   }
 
   pthread_key_t key_;
@@ -165,7 +165,7 @@ class ThreadLocal
   T get() const {
     return t_;
   }
-  void set(const T &t) {
+  void set(const T& t) {
     t_ = t;
   }
 

--- a/amtl/am-type-traits.h
+++ b/amtl/am-type-traits.h
@@ -41,11 +41,11 @@ struct remove_reference {
   typedef T type;
 };
 template <typename T>
-struct remove_reference<T &> {
+struct remove_reference<T&> {
   typedef T type;
 };
 template <typename T>
-struct remove_reference<T &&> {
+struct remove_reference<T&&> {
   typedef T type;
 };
 
@@ -120,9 +120,9 @@ template <typename T>
 struct is_function_ptr : false_type{};
 #if defined(_MSC_VER)
 template <typename ReturnType, typename ...ArgTypes>
-struct is_function_ptr<ReturnType (__cdecl *)(ArgTypes...)> : true_type{};
+struct is_function_ptr<ReturnType (__cdecl*)(ArgTypes...)> : true_type{};
 template <typename ReturnType, typename ...ArgTypes>
-struct is_function_ptr<ReturnType (__cdecl *)(ArgTypes..., ...)> : true_type{};
+struct is_function_ptr<ReturnType (__cdecl*)(ArgTypes..., ...)> : true_type{};
 #else
 template <typename ReturnType, typename ...ArgTypes>
 struct is_function_ptr<ReturnType (*)(ArgTypes...)> : true_type{};
@@ -131,7 +131,7 @@ struct is_function_ptr<ReturnType (*)(ArgTypes..., ...)> : true_type{};
 #endif
 
 template <typename T>
-struct is_function : public is_function_ptr<typename remove_cv<T>::type *>
+struct is_function : public is_function_ptr<typename remove_cv<T>::type*>
 {};
 
 template <typename T>

--- a/amtl/am-uniqueptr.h
+++ b/amtl/am-uniqueptr.h
@@ -48,13 +48,13 @@ class UniquePtr
    : t_(nullptr)
   {
   }
-  explicit UniquePtr(T *t)
+  explicit UniquePtr(T* t)
    : t_(t)
   {}
   UniquePtr(decltype(nullptr) n)
    : t_(nullptr)
   {}
-  UniquePtr(UniquePtr &&other)
+  UniquePtr(UniquePtr&& other)
   {
     t_ = other.t_;
     other.t_ = nullptr;
@@ -62,23 +62,23 @@ class UniquePtr
   ~UniquePtr() {
     delete t_;
   }
-  T *get() const {
+  T* get() const {
     return t_;
   }
-  T *take() {
+  T* take() {
     return ReturnAndVoid(t_);
   }
   void assign(T* ptr) {
     delete t_;
     t_ = ptr;
   }
-  T *operator *() const {
+  T* operator*() const {
     return t_;
   }
-  T *operator ->() const {
+  T* operator ->() const {
     return t_;
   }
-  T *operator =(UniquePtr &&other) {
+  T* operator =(UniquePtr&& other) {
     assign(other.take());
     return t_;
   }
@@ -91,11 +91,11 @@ class UniquePtr
   }
 
  private:
-  UniquePtr(const UniquePtr &other) = delete;
-  UniquePtr &operator =(const UniquePtr &other) = delete;
+  UniquePtr(const UniquePtr& other) = delete;
+  UniquePtr& operator =(const UniquePtr& other) = delete;
 
  private:
-  T *t_;
+  T* t_;
 };
 
 // Wrapper that automatically deletes its contents. The pointer can be taken
@@ -113,17 +113,17 @@ class UniquePtr<T[]>
   {
     other.t_ = nullptr;
   }
-  explicit UniquePtr(T *t)
+  explicit UniquePtr(T* t)
    : t_(t)
   {
   }
   ~UniquePtr() {
     delete [] t_;
   }
-  T *get() const {
+  T* get() const {
     return t_;
   }
-  T *take() {
+  T* take() {
     return ReturnAndVoid(t_);
   }
   explicit operator bool() const {
@@ -156,7 +156,7 @@ class UniquePtr<T[]>
   UniquePtr& operator =(const UniquePtr& other) = delete;
 
  private:
-  T *t_;
+  T* t_;
 };
 
 namespace impl {

--- a/amtl/am-utility.h
+++ b/amtl/am-utility.h
@@ -49,7 +49,7 @@ namespace ke {
 // Zero out a non-array pointer.
 template <typename T>
 static inline void
-MemsetZero(T *t)
+MemsetZero(T* t)
 {
   memset(t, 0, sizeof(*t));
 }

--- a/amtl/am-vector.h
+++ b/amtl/am-vector.h
@@ -49,7 +49,7 @@ class Vector : private AllocPolicy
   {
   }
 
-  Vector(Vector &&other)
+  Vector(Vector&& other)
    : AllocPolicy(Move(other))
   {
     data_ = other.data_;
@@ -63,7 +63,7 @@ class Vector : private AllocPolicy
   }
 
   template <typename U>
-  bool append(U &&item) {
+  bool append(U&& item) {
     if (!growIfNeeded(1))
       return false;
     new (&data_[nitems_]) T(ke::Forward<U>(item));
@@ -71,7 +71,7 @@ class Vector : private AllocPolicy
     return true;
   }
   template <typename U>
-  void infallibleAppend(U &&item) {
+  void infallibleAppend(U&& item) {
     assert(growIfNeeded(1));
     new (&data_[nitems_]) T(ke::Forward<U>(item));
     nitems_++;
@@ -84,7 +84,7 @@ class Vector : private AllocPolicy
   //
   // This is a linear-time operation.
   template <typename U>
-  bool insert(size_t at, U &&item) {
+  bool insert(size_t at, U&& item) {
     if (at == length())
       return append(ke::Forward<U>(item));
     if (!moveUp(at))
@@ -142,17 +142,17 @@ class Vector : private AllocPolicy
     destruct_live();
     nitems_ = 0;
   }
-  const T &back() const {
+  const T& back() const {
     return at(length() - 1);
   }
-  T &back() {
+  T& back() {
     return at(length() - 1);
   }
 
-  T *buffer() {
+  T* buffer() {
     return data_;
   }
-  const T *buffer() const {
+  const T* buffer() const {
     return data_;
   }
 
@@ -177,7 +177,7 @@ class Vector : private AllocPolicy
   }
 
   template <typename U>
-  bool extend(U &&other) {
+  bool extend(U&& other) {
     if (length() == 0) {
       *this = Move(other);
     } else {
@@ -189,7 +189,7 @@ class Vector : private AllocPolicy
     return true;
   }
 
-  Vector &operator =(Vector &&other) {
+  Vector& operator =(Vector&& other) {
     zap();
     data_ = other.data_;
     nitems_ = other.nitems_;
@@ -217,8 +217,8 @@ class Vector : private AllocPolicy
  private:
   // These are disallowed because they basically violate the failure handling
   // model for AllocPolicies and are also likely to have abysmal performance.
-  Vector(const Vector &other) = delete;
-  Vector &operator =(const Vector &other) = delete;
+  Vector(const Vector& other) = delete;
+  Vector& operator =(const Vector& other) = delete;
 
  private:
   void destruct_live() {

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -35,11 +35,11 @@
 
 using namespace ke;
 
-Test *Test::head = nullptr;
+Test* Test::head = nullptr;
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
-  Test *test = Test::first();
+  Test* test = Test::first();
   while (test) {
     if (argc >= 2 && strcmp(argv[1], test->name()) != 0) {
       test = test->next();
@@ -62,22 +62,22 @@ extern "C" void __cxa_pure_virtual()
   abort();
 }
 
-void *operator new(size_t amount)
+void* operator new(size_t amount)
 {
   return malloc(amount);
 }
 
-void *operator new[](size_t amount)
+void* operator new[](size_t amount)
 {
   return malloc(amount);
 }
 
-void operator delete(void *p)
+void operator delete(void* p)
 {
   free(p);
 }
 
-void operator delete[](void *p)
+void operator delete[](void* p)
 {
   free(p);
 }

--- a/tests/runner.h
+++ b/tests/runner.h
@@ -40,7 +40,7 @@ namespace ke {
 class Test
 {
  public:
-  Test(const char *name)
+  Test(const char* name)
    : name_(name),
      next_(head)
   {
@@ -49,29 +49,29 @@ class Test
 
   virtual bool Run() = 0;
 
-  const char *name() const {
+  const char* name() const {
     return name_;
   }
-  Test *next() const {
+  Test* next() const {
     return next_;
   }
 
-  static inline Test *first() {
+  static inline Test* first() {
     return head;
   }
 
  private:
-  static Test *head;
+  static Test* head;
 
  private:
-  const char *name_;
-  Test *next_;
+  const char* name_;
+  Test* next_;
 };
 
 static inline bool
-check(bool condition, const char *fmt, ...)
+check(bool condition, const char* fmt, ...)
 {
-  FILE *fp = condition ? stdout : stderr;
+  FILE* fp = condition ? stdout : stderr;
   if (condition)
     fprintf(fp, " -- Ok: ");
   else
@@ -85,7 +85,7 @@ check(bool condition, const char *fmt, ...)
 }
 
 static inline bool
-check_silent(bool condition, const char *fmt, ...)
+check_silent(bool condition, const char* fmt, ...)
 {
   if (condition)
     return true;
@@ -108,7 +108,7 @@ class FallibleMalloc
   {
   }
 
-  void *am_malloc(size_t amount) {
+  void* am_malloc(size_t amount) {
     if (shouldOutOfMemory_) {
       reportOutOfMemory();
       return nullptr;
@@ -119,7 +119,7 @@ class FallibleMalloc
     return ::malloc(amount);
 #endif
   }
-  void am_free(void *p) {
+  void am_free(void* p) {
 #if defined(_DEBUG) && defined(_CRTDBG_MAP_ALLOC)
     return free(p);
 #else

--- a/tests/test-callable.cpp
+++ b/tests/test-callable.cpp
@@ -132,8 +132,8 @@ class TestCallable : public Test
 
     struct {
       int a;
-      void *b, *c, *d, *e, *f, *g;
-      void *h, *j, *k, *m, *n, *o, *p;
+      void* b, *c, *d, *e, *f, *g;
+      void* h, *j, *k, *m, *n, *o, *p;
     } huge_struct = { 20 };
     CallDtorObj test_dtor;
     ptr = [huge_struct, test_dtor]() -> int {

--- a/tests/test-hashmap.cpp
+++ b/tests/test-hashmap.cpp
@@ -36,10 +36,10 @@ using namespace ke;
 
 struct StringPolicy
 {
-  static inline uint32_t hash(const char *key) {
+  static inline uint32_t hash(const char* key) {
     return FastHashCharSequence(key, strlen(key));
   }
-  static inline bool matches(const char *find, const AString &key) {
+  static inline bool matches(const char* find, const AString& key) {
     return key.compare(find) == 0;
   }
 };

--- a/tests/test-linkedlist.cpp
+++ b/tests/test-linkedlist.cpp
@@ -48,7 +48,7 @@ class BasicThing
   {
     sCtors++;
   }
-  BasicThing(const BasicThing &other)
+  BasicThing(const BasicThing& other)
   {
     sCopyCtors++;
   }
@@ -66,7 +66,7 @@ class MovingThing
   {
     sCtors++;
   }
-  MovingThing(MovingThing &&other)
+  MovingThing(MovingThing&& other)
   {
     assert(!other.moved_);
     sMovingCtors++;
@@ -81,7 +81,7 @@ class MovingThing
   }
 
  private:
-  MovingThing(const MovingThing &other) = delete;
+  MovingThing(const MovingThing& other) = delete;
   bool moved_;
 };
 

--- a/tests/test-refcounting.cpp
+++ b/tests/test-refcounting.cpp
@@ -58,7 +58,7 @@ TypeChecks_DoNotCall()
 }
 
 static inline RefPtr<Counted>
-PassThrough(const RefPtr<Counted> &obj)
+PassThrough(const RefPtr<Counted>& obj)
 {
   return obj;
 }
@@ -84,7 +84,7 @@ class TestRefcounting : public Test
     if (!check(sDtors == 2, "Ref/Newborn counted properly"))
       return false;
     {
-      Counted *counted = new Counted();
+      Counted* counted = new Counted();
       counted->AddRef();
       RefPtr<Counted> obj(AdoptRef(counted));
     }

--- a/tests/test-threadlocal-threaded.cpp
+++ b/tests/test-threadlocal-threaded.cpp
@@ -33,7 +33,7 @@
 using namespace ke;
 
 static ThreadLocal<int> sThreadVar;
-static ThreadLocal<void *> sThreadVarPointer;
+static ThreadLocal<void*> sThreadVarPointer;
 
 class VarThread
 {

--- a/tests/test-threadutils.cpp
+++ b/tests/test-threadutils.cpp
@@ -72,10 +72,10 @@ class TestWorkerModel
     }
   }
 
-  ConditionVariable *main() {
+  ConditionVariable* main() {
     return &main_;
   }
-  ConditionVariable *wakeup() {
+  ConditionVariable* wakeup() {
     return &wakeup_;
   }
 

--- a/tests/test-vector.cpp
+++ b/tests/test-vector.cpp
@@ -49,7 +49,7 @@ class BasicThing
   {
     sCtors++;
   }
-  BasicThing(const BasicThing &other)
+  BasicThing(const BasicThing& other)
   {
     sCopyCtors++;
   }
@@ -67,7 +67,7 @@ class MovingThing
   {
     sCtors++;
   }
-  MovingThing(MovingThing &&other)
+  MovingThing(MovingThing&& other)
   {
     assert(!other.moved_);
     sMovingCtors++;
@@ -80,7 +80,7 @@ class MovingThing
     if (moved_)
       sMovedDtors++;
   }
-  MovingThing &operator =(MovingThing &&other) {
+  MovingThing& operator =(MovingThing&& other) {
     assert(!other.moved_);
     sCopyCtors++;
     moved_ = false;
@@ -92,7 +92,7 @@ class MovingThing
   }
 
  private:
-  MovingThing(const MovingThing &other) = delete;
+  MovingThing(const MovingThing& other) = delete;
   bool moved_;
 };
 


### PR DESCRIPTION
Yep, let's do this to AMTL too. It's very inconsistent and the preferred style for years has been |T*| and |T&|.

Someday we should add clang formatters to these trees.