### PR TITLE
Fix A Warning — strcmpi @ am-string.h

### DIFF
--- a/amtl/am-string.h
+++ b/amtl/am-string.h
@@ -357,7 +357,7 @@ static inline int
 StrCaseCmp(const char* a, const char* b)
 {
 #if defined(_MSC_VER)
-  return strcmpi(a, b);
+  return _strcmpi(a, b);
 #else
   return strcasecmp(a, b);
 #endif


### PR DESCRIPTION
**strcmpi** should be **_strcmpi**