### PR TITLE
Remove all existing compiler workarounds.

### DIFF
--- a/.appveyor/build.bat
+++ b/.appveyor/build.bat
@@ -1,0 +1,7 @@
+@echo on
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
+mkdir opt32 && cd opt32
+C:\python27\python.exe ..\configure.py --enable-optimize
+C:\python27\python.exe C:\python27\Scripts\ambuild
+cd ..
+opt32\tests\testrunner\testrunner.exe

--- a/.appveyor/setup_environment.bat
+++ b/.appveyor/setup_environment.bat
@@ -1,0 +1,6 @@
+@echo on
+git submodule update --init
+git clone https://github.com/alliedmodders/ambuild ambuild
+cd ambuild
+c:\python27\python.exe setup.py install
+chdir /D "%APPVEYOR_BUILD_FOLDER%"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
       - lib32z1-dev
       - libc6-dev-i386
       - g++-multilib
-      - g++-4.8
+      - g++-4.9
 language: cpp
 sudo: false
 compiler:
@@ -28,14 +28,14 @@ script:
   - ./tests/testrunner/testrunner
   - cd ..
 
-  - mkdir build-gcc48-opt && cd build-clang-opt
-  - CC="gcc-4.8" CXX="g++-4.8" python ../configure.py --enable-optimize
+  - mkdir build-gcc49-opt && cd build-clang-opt
+  - CC="gcc-4.9" CXX="g++-4.9" python ../configure.py --enable-optimize
   - ambuild
   - ./tests/testrunner/testrunner
   - cd ..
 
-  - mkdir build-gcc48-debug && cd build-clang-debug
-  - CC="gcc-4.8" CXX="g++-4.8" python ../configure.py --enable-debug
+  - mkdir build-gcc49-debug && cd build-clang-debug
+  - CC="gcc-4.9" CXX="g++-4.9" python ../configure.py --enable-debug
   - ambuild
   - ./tests/testrunner/testrunner
   - cd ..

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ supporting a minimalistic set of abstractions and data structures useful for hig
 systems code. It is the spiritual succesor to the SourceHook template library.
 
 AMBuild currently requires C++11 support. The minimum supported compiler versions are:
- - Microsoft Visual Studio 2013 or higher.
- - GNU GCC 4.8 or higher (to run tests; otherwise, 4.7).
- - Clang 3.0 or higher.
+ - Microsoft Visual Studio 2015 or higher.
+ - GNU GCC 4.9 or higher.
+ - Clang 3.4 or higher.
 
 Specifically, it requires `nullptr`, `>>` support in templates, r-value references v2.0,
 (N2844), lambda support, and the override/delete keywords. The older, deprecated `C++98`

--- a/amtl/am-algorithm.h
+++ b/amtl/am-algorithm.h
@@ -57,7 +57,7 @@ Swap(T& left, T& right)
 template <typename T>
 struct LessThan
 {
-  KE_CONSTEXPR bool operator ()(const T& left, const T& right) const {
+  constexpr bool operator ()(const T& left, const T& right) const {
     return left < right;
   }
 };
@@ -65,7 +65,7 @@ struct LessThan
 template <typename T>
 struct GreaterThan
 {
-  KE_CONSTEXPR bool operator ()(const T& left, const T& right) const {
+  constexpr bool operator ()(const T& left, const T& right) const {
     return left > right;
   }
 };

--- a/amtl/am-cxx.h
+++ b/amtl/am-cxx.h
@@ -68,130 +68,26 @@
 # define KE_CLANG_AT_LEAST(x, y) \
    ((__clang_major__ > (x)) || (__clang_major__ == x && __clang_minor__ >= y))
 
-# if KE_CLANG_AT_LEAST(2, 9)
-#  define KE_CXX_HAS_RVAL_REFS 30
-#  define KE_CXX_HAS_DELETE
-#  define KE_CXX_HAS_STATIC_ASSERT
-#  define KE_CXX_HAS_DOUBLE_GT
-#  define KE_CXX_HAS_ENUM_CLASS
-# endif
-# if KE_CLANG_AT_LEAST(3, 0)
-#  define KE_CXX_HAS_OVERRIDE
-#  define KE_CXX_HAS_EXPLICIT_BOOL
-#  define KE_CXX_HAS_NULLPTR
-#  define KE_CXX_HAS_NOEXCEPT
-# endif
-# if KE_CLANG_AT_LEAST(3, 1)
-#  define KE_CXX_HAS_CONSTEXPR
-# endif
-# if KE_CLANG_AT_LEAST(3, 4)
-#  define KE_CXX_HAS_GENERIC_LAMBDA_CAPTURES
+# if !KE_CLANG_AT_LEAST(3, 4)
+#  error "AMTL requires clang 3.4 or higher"
 # endif
 
 #elif defined(__GNUC__)
 # define KE_GCC_AT_LEAST(x, y) ((__GNUC__ > (x)) || (__GNUC__ == x && __GNUC_MINOR__ >= y))
 
-# if KE_GCC_AT_LEAST(4, 3)
-#  define KE_CXX_HAS_RVAL_REFS 10
-#  define KE_CXX_HAS_STATIC_ASSERT
-#  define KE_CXX_HAS_DOUBLE_GT
-# endif
-# if KE_GCC_AT_LEAST(4, 4)
-#  define KE_CXX_HAS_DELETE
-#  define KE_CXX_HAS_ENUM_CLASS
-# endif
-# if KE_GCC_AT_LEAST(4, 5)
-#  define KE_CXX_HAS_EXPLICIT_BOOL
-#  undef KE_CXX_HAS_RVAL_REFS
-#  define KE_CXX_HAS_RVAL_REFS 21
-# endif
-# if KE_GCC_AT_LEAST(4, 6)
-#  define KE_CXX_HAS_NULLPTR
-#  define KE_CXX_HAS_NOEXCEPT
-#  define KE_CXX_HAS_CONSTEXPR
-#  undef KE_CXX_HAS_RVAL_REFS
-#  define KE_CXX_HAS_RVAL_REFS 30
-# endif
-# if KE_GCC_AT_LEAST(4, 7)
-#  define KE_CXX_HAS_OVERRIDE
-# endif
-# if KE_GCC_AT_LEAST(4, 9)
-#  define KE_CXX_HAS_GENERIC_LAMBDA_CAPTURES
+# if !KE_GCC_AT_LEAST(4, 9)
+#  error "AMTL requires GCC 4.9 or higher"
 # endif
 
 #elif defined(_MSC_VER)
-# if _MSC_VER >= 1600
-#  define KE_CXX_HAS_RVAL_REFS 20
-#  define KE_CXX_HAS_STATIC_ASSERT
-#  define KE_CXX_HAS_DOUBLE_GT
-#  define KE_CXX_HAS_NULLPTR
-# endif
-# if _MSC_VER >= 1700
-#  undef KE_CXX_HAS_RVAL_REFS
-#  define KE_CXX_HAS_RVAL_REFS 21
-#  define KE_CXX_HAS_OVERRIDE
-#  define KE_CXX_HAS_ENUM_CLASS
-# endif
-# if _MSC_VER >= 1800
-#  define KE_CXX_HAS_DELETE
-#  define KE_CXX_HAS_EXPLICIT_BOOL
-# endif
-# if _MSC_VER == 1800 && _MSC_FULL_VER == 180021114
-#  define KE_CXX_HAS_CONSTEXPR
-# endif
-# if _MSC_VER >= 1900
-#  define KE_CXX_HAS_CONSTEXPR
-#  define KE_CXX_HAS_NOEXCEPT
-#  define KE_CXX_HAS_GENERIC_LAMBDA_CAPTURES
+# if _MSC_VER < 1900
+#  error "AMTL requires Microsoft Visual Studio 2015 or higher"
 # endif
 #else
-# error Unrecognized compiler.
+# error "Unrecognized compiler."
 #endif
 
 // Done with compiler feature detection.
-
-#if !defined(KE_CXX_HAS_OVERRIDE)
-# error "AMTL requires C++11 override"
-#endif
-#if !defined(KE_CXX_HAS_DELETE)
-# error "AMTL requires C++11 method deletion"
-#endif
-#if !defined(KE_CXX_HAS_EXPLICIT_BOOL)
-# error "AMTL requires C++11 explicit bool"
-#endif
-
-#if defined(KE_CXX_HAS_NOEXCEPT)
-# define KE_NOEXCEPT noexcept
-#else
-# define KE_NOEXCEPT
-#endif
-
-#if defined(KE_CXX_HAS_CONSTEXPR)
-# define KE_CONSTEXPR constexpr
-#else
-# define KE_CONSTEXPR
-#endif
-
-#if defined(KE_CXX_HAS_STATIC_ASSERT)
-# define KE_STATIC_ASSERT(cond) static_assert(cond, #cond)
-#else
-# define KE_STATIC_ASSERT(cond) extern int static_assert_f(int a[(cond) ? 1 : -1])
-#endif
-
-#if !defined(KE_CXX_HAS_RVAL_REFS) || KE_CXX_HAS_RVAL_REFS < 21
-//# error AMTL requires rvalue reference 2.1 support (N2844+)
-#endif
-#if !defined(KE_CXX_HAS_DOUBLE_GT)
-# error AMTL requires support for >> in template names
-#endif
-#if !defined(KE_CXX_HAS_NULLPTR)
-# if defined(__GNUC__) && !defined(__clang__)
-#  define nullptr __null
-#  define KE_CXX_HAS_NULLPTR
-# else
-#  error AMTL requires nullptr support
-# endif
-#endif
 
 #if defined(_MSC_VER)
 // This feature has been around for long enough that we shouldn't have to

--- a/amtl/am-moveable.h
+++ b/amtl/am-moveable.h
@@ -47,15 +47,15 @@ Move(T&& t)
 //   http://thbecker.net/articles/rvalue_references/section_07.html and
 //   http://thbecker.net/articles/rvalue_references/section_08.html
 template <typename T>
-static KE_CONSTEXPR inline T &&
-Forward(typename remove_reference<T>::type& t) KE_NOEXCEPT
+static constexpr inline T &&
+Forward(typename remove_reference<T>::type& t) noexcept
 {
   return static_cast<T&&>(t);
 }
 
 template <typename T>
-static KE_CONSTEXPR inline T &&
-Forward(typename remove_reference<T>::type&& t) KE_NOEXCEPT
+static constexpr inline T &&
+Forward(typename remove_reference<T>::type&& t) noexcept
 {
   return static_cast<T&&>(t);
 }

--- a/amtl/am-priority-queue.h
+++ b/amtl/am-priority-queue.h
@@ -127,16 +127,16 @@ class PriorityQueue final
     }
   }
 
-  static KE_CONSTEXPR size_t parentOf(size_t at) {
+  static constexpr size_t parentOf(size_t at) {
 #if __cplusplus >= 201402L
     assert(at > 0);
 #endif
     return (at - 1) / 2;
   }
-  static KE_CONSTEXPR size_t leftChildOf(size_t at) {
+  static constexpr size_t leftChildOf(size_t at) {
     return (at * 2) + 1;
   }
-  static KE_CONSTEXPR size_t rightChildOf(size_t at) {
+  static constexpr size_t rightChildOf(size_t at) {
     return (at * 2) + 2;
   }
 

--- a/amtl/experimental/am-argparser.h
+++ b/amtl/experimental/am-argparser.h
@@ -363,7 +363,7 @@ class RepeatOption : public VectorOption<Type>
 struct BaseValuePolicy
 { 
   // Return true if an argument of this type can omit a value.
-  static KE_CONSTEXPR bool canOmitValue() {
+  static constexpr bool canOmitValue() {
     return false;
   }
 };
@@ -371,7 +371,7 @@ struct BaseValuePolicy
 template <>
 struct ValuePolicy<bool>
 {
-  static KE_CONSTEXPR bool canOmitValue() {
+  static constexpr bool canOmitValue() {
     return true;
   }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,6 @@
+version: 1.0.{build}
+clone_folder: c:\projects\amtl
+install:
+- cmd: .appveyor\setup_environment.bat
+build_script:
+- cmd: .appveyor\build.bat

--- a/tests/test-callable.cpp
+++ b/tests/test-callable.cpp
@@ -183,15 +183,8 @@ TEST(Callable, Move)
   auto fn = [test_dtor]{};
   Lambda<void()> ptr4 = ke::Move(fn);
   EXPECT_EQ(ctors, (size_t)0);
-#if !defined(_MSC_VER) || (_MSC_VER >= 1900)
   EXPECT_EQ(copyctors, (size_t)1);
   EXPECT_EQ(movectors, (size_t)1);
-#else
-  // Older Microsoft compilers do not implement move semantics for lambda
-  // types, unfortunately.
-  EXPECT_EQ(copyctors, (size_t)2);
-  EXPECT_EQ(movectors, (size_t)0);
-#endif
   EXPECT_EQ(dtors, (size_t)0);
 }
 
@@ -215,7 +208,6 @@ TEST(Callable, FuncPtr)
 
 TEST(Callable, MoveUncopyable)
 {
-#if defined(KE_CXX_HAS_GENERIC_LAMBDA_CAPTURES)
   Vector<int> v;
 
   auto lambda = [v = Move(v)]() -> size_t {
@@ -226,5 +218,4 @@ TEST(Callable, MoveUncopyable)
   Function<size_t()> f = ke::Move(lambda);
 
   EXPECT_EQ(f(), (size_t)0);
-#endif
 }

--- a/tests/test-threadlocal-threaded.cpp
+++ b/tests/test-threadlocal-threaded.cpp
@@ -45,10 +45,10 @@ class VarThread
   }
 
   void Run() {
-    ASSERT_EQ(sThreadVar, 0);
+    ASSERT_EQ(sThreadVar.get(), 0);
 
     sThreadVar = 20;
-    ASSERT_EQ(sThreadVar, 20);
+    ASSERT_EQ(sThreadVar.get(), 20);
 
     succeeded_ = true;
   }
@@ -73,9 +73,9 @@ TEST(ThreadLocal, Threaded)
   thread->Join();
 
   ASSERT_TRUE(run.succeeded());
-  EXPECT_EQ(sThreadVar, 10);
+  EXPECT_EQ(sThreadVar.get(), 10);
 
   // Check that pointers are allowed in T.
   sThreadVarPointer = &run;
-  EXPECT_EQ(sThreadVarPointer, &run);
+  EXPECT_EQ(sThreadVarPointer.get(), &run);
 }

--- a/tests/test-threadlocal-unthreaded.cpp
+++ b/tests/test-threadlocal-unthreaded.cpp
@@ -38,7 +38,7 @@ static ThreadLocal<int> sVar;
 
 TEST(ThreadLocal, Unthreaded)
 {
-  EXPECT_EQ(sVar, 0);
+  EXPECT_EQ(sVar.get(), 0);
   sVar = 10;
-  EXPECT_EQ(sVar, 10);
+  EXPECT_EQ(sVar.get(), 10);
 }


### PR DESCRIPTION
This bumps the minimum compilers to GCC 4.9 (from 4.6), MSVC 2015 (from 2013), and Clang 3.4 (from 3.0). The workaround header (am-cxx.h) is much simpler now.