### PR TITLE
Improve the argument parser.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -162,6 +162,11 @@ class KEConfig(object):
 KE = KEConfig()
 KE.configure()
 
+KE.libamtl = builder.RunScript('amtl/AMBuilder', {
+    'Configure': lambda builder, name: KE.StaticLibrary(builder, name),
+})
+KE.libamtl = KE.libamtl.binary
+
 builder.RunBuildScripts(
   [
     'tests/AMBuild.tests',

--- a/amtl/AMBuilder
+++ b/amtl/AMBuilder
@@ -1,0 +1,29 @@
+# vim: set ts=8 sts=2 sw=2 tw=99 et ft=python: 
+# 
+# Copyright (C) 2004-2012 David Anderson
+# 
+# This file is part of SourcePawn.
+# 
+# SourcePawn is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+# 
+# SourcePawn is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along with
+# SourcePawn. If not, see http://www.gnu.org/licenses/.
+#
+import os
+
+binary = Configure(builder, 'libamtl')
+binary.compiler.includes += [
+  os.path.join(builder.sourcePath),
+]
+binary.sources += [
+  'experimental/am-argparser.cc',
+]
+
+rvalue = builder.Add(binary)

--- a/amtl/am-string.h
+++ b/amtl/am-string.h
@@ -1,4 +1,4 @@
-// vim: set sts=8 ts=2 sw=2 tw=99 et:
+// vim: set sts=8 ts=4 sw=4 tw=99 et:
 //
 // Copyright (C) 2013, David Anderson and AlliedModders LLC
 // All rights reserved.
@@ -176,6 +176,10 @@ class AString
             buffer[i] = tolower(chars_[i]);
         buffer[length_] = '\0';
         return AString(Move(buffer), length_);
+    }
+
+    bool empty() const {
+        return length_ == 0;
     }
 
   private:

--- a/amtl/experimental/am-argparser.cc
+++ b/amtl/experimental/am-argparser.cc
@@ -1,0 +1,38 @@
+// vim: set sts=8 ts=4 sw=4 tw=99 et:
+//
+// Copyright (C) 2018, David Anderson and AlliedModders LLC
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  * Neither the name of AlliedModders LLC nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <amtl/experimental/am-argparser.h>
+
+namespace ke {
+namespace args {
+
+Vector<IOption*> *Parser::sStaticOptions = nullptr;
+
+} // namespace args
+} // namespace ke

--- a/tests/AMBuild.tests
+++ b/tests/AMBuild.tests
@@ -40,6 +40,7 @@ if compiler.like('msvc'):
 if builder.target_platform == 'linux':
   compiler.linkflags.append('-ldl')
 compiler.linkflags.append(libgtest.binary)
+compiler.linkflags.append(KE.libamtl)
 
 binary.sources += [
   'main.cpp',

--- a/tests/test-argparser.cpp
+++ b/tests/test-argparser.cpp
@@ -1,4 +1,4 @@
-// vim: set sts=8 ts=2 sw=2 tw=99 et:
+// vim: set sts=8 ts=4 sw=4 tw=99 et:
 //
 // Copyright (C) 2013, David Anderson and AlliedModders LLC
 // All rights reserved.
@@ -184,4 +184,46 @@ TEST(ArgParser, StopArg2) {
 
     EXPECT_TRUE(parser.parsev("-v", "-w", nullptr));
     EXPECT_TRUE(show_version.value());
+}
+
+TEST(ArgParser, NoSeparator) {
+    Parser parser("help");
+    parser.enable_inline_values();
+
+    IntOption opt(parser, "-O", nullptr, {}, "Optimization level");
+
+    ASSERT_TRUE(parser.parsev("-O2", nullptr));
+    EXPECT_EQ(opt.value(), 2);
+}
+
+TEST(ArgParser, ColonSeparator) {
+    Parser parser("help");
+    parser.enable_inline_values();
+
+    IntOption opt(parser, "-O", nullptr, {}, "Optimization level");
+
+    ASSERT_TRUE(parser.parsev("-O:2", nullptr));
+    EXPECT_EQ(opt.value(), 2);
+}
+
+TEST(ArgParser, Slashes) {
+    Parser parser("help");
+    parser.enable_inline_values();
+    parser.allow_slashes();
+
+    IntOption opt(parser, "-O", nullptr, {}, "Optimization level");
+
+    ASSERT_TRUE(parser.parsev("/O:2", nullptr));
+    EXPECT_EQ(opt.value(), 2);
+}
+
+TEST(ArgParser, CollectExtra) {
+    Parser parser("help");
+    parser.collect_extra_args();
+
+    ASSERT_TRUE(parser.parsev("a", "b", "c", nullptr));
+    ASSERT_EQ(parser.extra_args().length(), (unsigned)3);
+    EXPECT_EQ(parser.extra_args()[0].compare("a"), 0);
+    EXPECT_EQ(parser.extra_args()[1].compare("b"), 0);
+    EXPECT_EQ(parser.extra_args()[2].compare("c"), 0);
 }


### PR DESCRIPTION
Support inline options as spcomp does, where -O2 and -O:2 are allowed.

Support slash options for spcomp compatibility.

Support unaccounted positionals.

Support global static arguments, and add a new libamtl AMBuilder snippet
for embedders to link the necessary support.

Fix some style problems missed by amrestyler while here.