### PR TITLE
Restore ke::Function.

### DIFF
--- a/amtl/am-function.h
+++ b/amtl/am-function.h
@@ -1,0 +1,445 @@
+// vim: set sts=8 ts=2 sw=2 tw=99 et:
+//
+// Copyright (C) 2013-2015, David Anderson and AlliedModders LLC
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above cloneright notice, this
+//    list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above cloneright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  * Neither the name of AlliedModders LLC nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifndef _include_amtl_function_h_
+#define _include_amtl_function_h_
+
+#include <amtl/am-moveable.h>
+#include <amtl/am-type-traits.h>
+#include <assert.h>
+#include <new>
+
+namespace ke {
+
+namespace impl {
+template <typename ReturnType, typename... ArgTypes>
+class FunctionHolderBase
+{
+  public:
+    virtual ~FunctionHolderBase() {}
+    virtual ReturnType invoke(ArgTypes&&... argv) = 0;
+    virtual FunctionHolderBase<ReturnType, ArgTypes...>* move(void* mem) = 0;
+};
+
+template <typename T, typename ReturnType, typename... ArgTypes>
+class FunctionHolder : public FunctionHolderBase<ReturnType, ArgTypes...>
+{
+    typedef FunctionHolderBase<ReturnType, ArgTypes...> BaseType;
+
+  public:
+    FunctionHolder(FunctionHolder&& other)
+     : obj_(ke::Move(other.obj_))
+    {}
+    FunctionHolder(T&& obj)
+     : obj_(ke::Move(obj))
+    {}
+
+    virtual ~FunctionHolder() override {}
+    virtual ReturnType invoke(ArgTypes&&... argv) override {
+        return obj_(ke::Forward<ArgTypes>(argv)...);
+    }
+    virtual BaseType* move(void* mem) override {
+        new (mem) FunctionHolder(ke::Move(*this));
+        return (BaseType*)mem;
+    }
+
+  private:
+    T obj_;
+};
+
+static const size_t kMinFunctionInlineBufferSize = sizeof(void*) * 3;
+} // namespace impl
+
+template <typename Tk>
+class Function;
+
+template <typename ReturnType, typename... ArgTypes>
+class Function<ReturnType(ArgTypes...)>
+{
+    typedef impl::FunctionHolderBase<ReturnType, ArgTypes...> HolderType;
+
+  public:
+    Function()
+     : impl_(nullptr)
+    {}
+    Function(decltype(nullptr))
+     : impl_(nullptr)
+    {}
+    Function(Function&& other) {
+        move(ke::Forward<Function>(other));
+    }
+
+    template <typename T>
+    Function(T&& obj) {
+        assign(ke::Forward<T>(obj));
+    }
+
+    ~Function() {
+        destroy();
+    }
+
+    Function& operator =(decltype(nullptr)) {
+        destroy();
+        impl_ = nullptr;
+        return *this;
+    }
+    Function& operator =(Function&& other) {
+        destroy();
+        move(ke::Move(other));
+        return *this;
+    }
+
+    template <typename T>
+    Function& operator =(T&& other) {
+        destroy();
+        assign(ke::Forward<T>(other));
+        return *this;
+    }
+
+    explicit operator bool() const {
+        return !!impl_;
+    }
+
+    ReturnType operator ()(ArgTypes... argv) const {
+        assert(impl_);
+        return impl_->invoke(ke::Forward<ArgTypes>(argv)...);
+    }
+
+    bool usingInlineStorage() const {
+        return (void*)impl_ == &buffer_;
+    }
+
+  private:
+    void destroy() {
+        if (!impl_)
+            return;
+
+        if (usingInlineStorage())
+            impl_->~HolderType();
+        else
+            delete impl_;
+    }
+    void zap() {
+        destroy();
+        impl_ = nullptr;
+    }
+
+    void* inline_buffer() {
+        return &buffer_;
+    }
+
+    void move(Function&& other) {
+        if (!other) {
+            impl_ = nullptr;
+        } else if (other.usingInlineStorage()) {
+            impl_ = other.impl_->move(inline_buffer());
+            other.zap();
+        } else {
+            impl_ = other.impl_;
+            other.impl_ = nullptr;
+        }
+    }
+
+    template <typename T>
+    void assign(T&& obj) {
+        typedef typename ke::decay<T>::type CallableType;
+        typedef impl::FunctionHolder<CallableType, ReturnType, ArgTypes...> ImplType;
+
+        if (sizeof(ImplType) <= sizeof(buffer_)) {
+            impl_ = reinterpret_cast<ImplType*>(inline_buffer());
+            new (inline_buffer()) ImplType(ke::Forward<T>(obj));
+        } else {
+            impl_ = new ImplType(ke::Forward<T>(obj));
+        }
+    }
+
+  private:
+    HolderType* impl_;
+    union {
+        double alignment_;
+        char alias_[impl::kMinFunctionInlineBufferSize];
+    } buffer_;
+};
+
+namespace impl {
+template <typename ReturnType, typename... ArgTypes>
+class LambdaHolderBase
+{
+  public:
+    virtual ~LambdaHolderBase() {}
+    virtual ReturnType invoke(ArgTypes&&... argv) const = 0;
+    virtual LambdaHolderBase<ReturnType, ArgTypes...>* clone(void* mem) const = 0;
+    virtual LambdaHolderBase<ReturnType, ArgTypes...>* move(void* mem) = 0;
+};
+
+template <typename T, typename ReturnType, typename... ArgTypes>
+class LambdaHolder : public LambdaHolderBase<ReturnType, ArgTypes...>
+{
+    typedef LambdaHolderBase<ReturnType, ArgTypes...> BaseType;
+
+  public:
+    LambdaHolder(const LambdaHolder& other)
+     : obj_(other.obj_)
+    {}
+    LambdaHolder(LambdaHolder&& other)
+     : obj_(ke::Move(other.obj_))
+    {}
+    LambdaHolder(const T& obj)
+     : obj_(obj)
+    {}
+    LambdaHolder(T&& obj)
+     : obj_(ke::Move(obj))
+    {}
+
+    virtual ~LambdaHolder() {}
+    virtual ReturnType invoke(ArgTypes&&... argv) const override {
+        return obj_(ke::Forward<ArgTypes>(argv)...);
+    }
+    virtual BaseType* clone(void* mem) const override {
+        if (!mem)
+            return new LambdaHolder(*this);
+        new (mem) LambdaHolder(*this);
+        return (BaseType*)mem;
+    }
+    virtual BaseType* move(void* mem) override {
+        new (mem) LambdaHolder(ke::Move(*this));
+        return (BaseType*)mem;
+    }
+
+  private:
+    T obj_;
+};
+
+static const size_t kMinLambdaInlineBufferSize = sizeof(void*) * 3;
+} // namespace impl
+
+template <typename Tk>
+class Lambda;
+
+template <typename ReturnType, typename... ArgTypes>
+class Lambda<ReturnType(ArgTypes...)>
+{
+    typedef impl::LambdaHolderBase<ReturnType, ArgTypes...> HolderType;
+
+  public:
+    Lambda()
+     : impl_(nullptr)
+    {}
+    Lambda(decltype(nullptr))
+     : impl_(nullptr)
+    {}
+    Lambda(const Lambda& other) {
+        assign(other);
+    }
+    Lambda(Lambda&& other) {
+        move(ke::Forward<Lambda>(other));
+    }
+
+    template <typename T>
+    Lambda(T&& obj) {
+        assign(ke::Forward<T>(obj));
+    }
+
+    ~Lambda() {
+        destroy();
+    }
+
+    Lambda& operator =(decltype(nullptr)) {
+        destroy();
+        impl_ = nullptr;
+        return *this;
+    }
+    Lambda& operator =(const Lambda& other) {
+        destroy();
+        assign(other);
+        return *this;
+    }
+    Lambda& operator =(Lambda&& other) {
+        destroy();
+        move(ke::Move(other));
+        return *this;
+    }
+
+    template <typename T>
+    Lambda& operator =(T&& other) {
+        destroy();
+        assign(other);
+        return *this;
+    }
+
+    explicit operator bool() const {
+        return !!impl_;
+    }
+
+    ReturnType operator ()(ArgTypes... argv) const {
+        assert(impl_);
+        return impl_->invoke(ke::Forward<ArgTypes>(argv)...);
+    }
+
+    bool usingInlineStorage() const {
+        return (void*)impl_ == &buffer_;
+    }
+
+  private:
+    void destroy() {
+        if (!impl_)
+            return;
+
+        if (usingInlineStorage())
+            impl_->~HolderType();
+        else
+            delete impl_;
+    }
+    void zap() {
+        destroy();
+        impl_ = nullptr;
+    }
+
+    void* inline_buffer() {
+        return &buffer_;
+    }
+
+    void assign(const Lambda& other) {
+        if (!other)
+            impl_ = nullptr;
+        else if (other.usingInlineStorage())
+            impl_ = other.impl_->clone(inline_buffer());
+        else
+            impl_ = other.impl_->clone(nullptr);
+    }
+
+    void move(Lambda&& other) {
+        if (!other) {
+            impl_ = nullptr;
+        } else if (other.usingInlineStorage()) {
+            impl_ = other.impl_->move(inline_buffer());
+            other.zap();
+        } else {
+            impl_ = other.impl_;
+            other.impl_ = nullptr;
+        }
+    }
+
+    template <typename T>
+    void assign(T&& obj) {
+        typedef typename ke::decay<T>::type CallableType;
+        typedef impl::LambdaHolder<CallableType, ReturnType, ArgTypes...> ImplType;
+
+        if (sizeof(ImplType) <= sizeof(buffer_)) {
+            impl_ = reinterpret_cast<ImplType*>(inline_buffer());
+            new (inline_buffer()) ImplType(ke::Forward<T>(obj));
+        } else {
+            impl_ = new ImplType(ke::Forward<T>(obj));
+        }
+    }
+
+  private:
+    HolderType* impl_;
+    union {
+        double alignment_;
+        char alias_[impl::kMinLambdaInlineBufferSize];
+    } buffer_;
+};
+
+template <typename Tk>
+class FuncPtr;
+
+template <typename ReturnType, typename... ArgTypes>
+class FuncPtr<ReturnType(ArgTypes...)>
+{
+    typedef ReturnType (*Invoker)(void*, ArgTypes&&...);
+
+  public:
+    FuncPtr()
+     : ptr_(nullptr)
+    {}
+    FuncPtr(const FuncPtr& other)
+     : ptr_(other.ptr_),
+       invoker_(other.invoker_)
+    {}
+    FuncPtr(ReturnType (*fn)(ArgTypes...)) {
+        assignStatic(fn);
+    }
+    template <typename T>
+    FuncPtr(T* obj) {
+        assignFunctor(obj);
+    }
+
+    FuncPtr& operator =(decltype(nullptr)) {
+        ptr_ = nullptr;
+        invoker_ = nullptr;
+        return *this;
+    }
+    FuncPtr& operator =(const FuncPtr& other) {
+        ptr_ = other.ptr_;
+        invoker_ = other.invoker_;
+        return *this;
+    }
+    FuncPtr& operator =(ReturnType (*fn)(ArgTypes...)) {
+        assignStatic(fn);
+        return *this;
+    }
+    template <typename T>
+    FuncPtr& operator =(T* obj) {
+        assignFunctor(obj);
+        return *this;
+    }
+
+    explicit operator bool() const {
+        return !!ptr_;
+    }
+
+    ReturnType operator ()(ArgTypes... argv) const {
+        assert(ptr_ && invoker_);
+        return invoker_(ptr_, ke::Forward<ArgTypes>(argv)...);
+    }
+
+  private:
+    void assignStatic(ReturnType (*fn)(ArgTypes...)) {
+        typedef decltype(fn) FnType;
+        ptr_ = reinterpret_cast<void*>(fn);
+        invoker_ = [](void* ptr, ArgTypes&&... argv) {
+            return (reinterpret_cast<FnType>(ptr))(ke::Forward<ArgTypes>(argv)...);
+        };
+    }
+    template <typename T>
+    void assignFunctor(T* obj) {
+        ptr_ = obj;
+        invoker_ = [](void* ptr, ArgTypes&&... argv) {
+            return (reinterpret_cast<T*>(ptr))->operator()(ke::Forward<ArgTypes>(argv)...);
+        };
+    }
+
+  private:
+    void* ptr_;
+    Invoker invoker_;
+};
+
+} // namespace ke
+
+#endif // _include_amtl_function_h_

--- a/amtl/am-function.h
+++ b/amtl/am-function.h
@@ -42,7 +42,8 @@ class FunctionHolderBase
 {
   public:
     virtual ~FunctionHolderBase() {}
-    virtual ReturnType invoke(ArgTypes&&... argv) = 0;
+    virtual ReturnType invoke(ArgTypes&&... argv) const = 0;
+    virtual FunctionHolderBase<ReturnType, ArgTypes...>* clone(void* mem) const = 0;
     virtual FunctionHolderBase<ReturnType, ArgTypes...>* move(void* mem) = 0;
 };
 
@@ -52,16 +53,28 @@ class FunctionHolder : public FunctionHolderBase<ReturnType, ArgTypes...>
     typedef FunctionHolderBase<ReturnType, ArgTypes...> BaseType;
 
   public:
+    FunctionHolder(const FunctionHolder& other)
+     : obj_(other.obj_)
+    {}
     FunctionHolder(FunctionHolder&& other)
      : obj_(ke::Move(other.obj_))
+    {}
+    FunctionHolder(const T& obj)
+     : obj_(obj)
     {}
     FunctionHolder(T&& obj)
      : obj_(ke::Move(obj))
     {}
 
-    virtual ~FunctionHolder() override {}
-    virtual ReturnType invoke(ArgTypes&&... argv) override {
+    virtual ~FunctionHolder() {}
+    virtual ReturnType invoke(ArgTypes&&... argv) const override {
         return obj_(ke::Forward<ArgTypes>(argv)...);
+    }
+    virtual BaseType* clone(void* mem) const override {
+        if (!mem)
+            return new FunctionHolder(*this);
+        new (mem) FunctionHolder(*this);
+        return (BaseType*)mem;
     }
     virtual BaseType* move(void* mem) override {
         new (mem) FunctionHolder(ke::Move(*this));
@@ -90,6 +103,9 @@ class Function<ReturnType(ArgTypes...)>
     Function(decltype(nullptr))
      : impl_(nullptr)
     {}
+    Function(const Function& other) {
+        assign(other);
+    }
     Function(Function&& other) {
         move(ke::Forward<Function>(other));
     }
@@ -108,6 +124,11 @@ class Function<ReturnType(ArgTypes...)>
         impl_ = nullptr;
         return *this;
     }
+    Function& operator =(const Function& other) {
+        destroy();
+        assign(other);
+        return *this;
+    }
     Function& operator =(Function&& other) {
         destroy();
         move(ke::Move(other));
@@ -117,7 +138,7 @@ class Function<ReturnType(ArgTypes...)>
     template <typename T>
     Function& operator =(T&& other) {
         destroy();
-        assign(ke::Forward<T>(other));
+        assign(other);
         return *this;
     }
 
@@ -151,6 +172,15 @@ class Function<ReturnType(ArgTypes...)>
 
     void* inline_buffer() {
         return &buffer_;
+    }
+
+    void assign(const Function& other) {
+        if (!other)
+            impl_ = nullptr;
+        else if (other.usingInlineStorage())
+            impl_ = other.impl_->clone(inline_buffer());
+        else
+            impl_ = other.impl_->clone(nullptr);
     }
 
     void move(Function&& other) {
@@ -184,260 +214,6 @@ class Function<ReturnType(ArgTypes...)>
         double alignment_;
         char alias_[impl::kMinFunctionInlineBufferSize];
     } buffer_;
-};
-
-namespace impl {
-template <typename ReturnType, typename... ArgTypes>
-class LambdaHolderBase
-{
-  public:
-    virtual ~LambdaHolderBase() {}
-    virtual ReturnType invoke(ArgTypes&&... argv) const = 0;
-    virtual LambdaHolderBase<ReturnType, ArgTypes...>* clone(void* mem) const = 0;
-    virtual LambdaHolderBase<ReturnType, ArgTypes...>* move(void* mem) = 0;
-};
-
-template <typename T, typename ReturnType, typename... ArgTypes>
-class LambdaHolder : public LambdaHolderBase<ReturnType, ArgTypes...>
-{
-    typedef LambdaHolderBase<ReturnType, ArgTypes...> BaseType;
-
-  public:
-    LambdaHolder(const LambdaHolder& other)
-     : obj_(other.obj_)
-    {}
-    LambdaHolder(LambdaHolder&& other)
-     : obj_(ke::Move(other.obj_))
-    {}
-    LambdaHolder(const T& obj)
-     : obj_(obj)
-    {}
-    LambdaHolder(T&& obj)
-     : obj_(ke::Move(obj))
-    {}
-
-    virtual ~LambdaHolder() {}
-    virtual ReturnType invoke(ArgTypes&&... argv) const override {
-        return obj_(ke::Forward<ArgTypes>(argv)...);
-    }
-    virtual BaseType* clone(void* mem) const override {
-        if (!mem)
-            return new LambdaHolder(*this);
-        new (mem) LambdaHolder(*this);
-        return (BaseType*)mem;
-    }
-    virtual BaseType* move(void* mem) override {
-        new (mem) LambdaHolder(ke::Move(*this));
-        return (BaseType*)mem;
-    }
-
-  private:
-    T obj_;
-};
-
-static const size_t kMinLambdaInlineBufferSize = sizeof(void*) * 3;
-} // namespace impl
-
-template <typename Tk>
-class Lambda;
-
-template <typename ReturnType, typename... ArgTypes>
-class Lambda<ReturnType(ArgTypes...)>
-{
-    typedef impl::LambdaHolderBase<ReturnType, ArgTypes...> HolderType;
-
-  public:
-    Lambda()
-     : impl_(nullptr)
-    {}
-    Lambda(decltype(nullptr))
-     : impl_(nullptr)
-    {}
-    Lambda(const Lambda& other) {
-        assign(other);
-    }
-    Lambda(Lambda&& other) {
-        move(ke::Forward<Lambda>(other));
-    }
-
-    template <typename T>
-    Lambda(T&& obj) {
-        assign(ke::Forward<T>(obj));
-    }
-
-    ~Lambda() {
-        destroy();
-    }
-
-    Lambda& operator =(decltype(nullptr)) {
-        destroy();
-        impl_ = nullptr;
-        return *this;
-    }
-    Lambda& operator =(const Lambda& other) {
-        destroy();
-        assign(other);
-        return *this;
-    }
-    Lambda& operator =(Lambda&& other) {
-        destroy();
-        move(ke::Move(other));
-        return *this;
-    }
-
-    template <typename T>
-    Lambda& operator =(T&& other) {
-        destroy();
-        assign(other);
-        return *this;
-    }
-
-    explicit operator bool() const {
-        return !!impl_;
-    }
-
-    ReturnType operator ()(ArgTypes... argv) const {
-        assert(impl_);
-        return impl_->invoke(ke::Forward<ArgTypes>(argv)...);
-    }
-
-    bool usingInlineStorage() const {
-        return (void*)impl_ == &buffer_;
-    }
-
-  private:
-    void destroy() {
-        if (!impl_)
-            return;
-
-        if (usingInlineStorage())
-            impl_->~HolderType();
-        else
-            delete impl_;
-    }
-    void zap() {
-        destroy();
-        impl_ = nullptr;
-    }
-
-    void* inline_buffer() {
-        return &buffer_;
-    }
-
-    void assign(const Lambda& other) {
-        if (!other)
-            impl_ = nullptr;
-        else if (other.usingInlineStorage())
-            impl_ = other.impl_->clone(inline_buffer());
-        else
-            impl_ = other.impl_->clone(nullptr);
-    }
-
-    void move(Lambda&& other) {
-        if (!other) {
-            impl_ = nullptr;
-        } else if (other.usingInlineStorage()) {
-            impl_ = other.impl_->move(inline_buffer());
-            other.zap();
-        } else {
-            impl_ = other.impl_;
-            other.impl_ = nullptr;
-        }
-    }
-
-    template <typename T>
-    void assign(T&& obj) {
-        typedef typename ke::decay<T>::type CallableType;
-        typedef impl::LambdaHolder<CallableType, ReturnType, ArgTypes...> ImplType;
-
-        if (sizeof(ImplType) <= sizeof(buffer_)) {
-            impl_ = reinterpret_cast<ImplType*>(inline_buffer());
-            new (inline_buffer()) ImplType(ke::Forward<T>(obj));
-        } else {
-            impl_ = new ImplType(ke::Forward<T>(obj));
-        }
-    }
-
-  private:
-    HolderType* impl_;
-    union {
-        double alignment_;
-        char alias_[impl::kMinLambdaInlineBufferSize];
-    } buffer_;
-};
-
-template <typename Tk>
-class FuncPtr;
-
-template <typename ReturnType, typename... ArgTypes>
-class FuncPtr<ReturnType(ArgTypes...)>
-{
-    typedef ReturnType (*Invoker)(void*, ArgTypes&&...);
-
-  public:
-    FuncPtr()
-     : ptr_(nullptr)
-    {}
-    FuncPtr(const FuncPtr& other)
-     : ptr_(other.ptr_),
-       invoker_(other.invoker_)
-    {}
-    FuncPtr(ReturnType (*fn)(ArgTypes...)) {
-        assignStatic(fn);
-    }
-    template <typename T>
-    FuncPtr(T* obj) {
-        assignFunctor(obj);
-    }
-
-    FuncPtr& operator =(decltype(nullptr)) {
-        ptr_ = nullptr;
-        invoker_ = nullptr;
-        return *this;
-    }
-    FuncPtr& operator =(const FuncPtr& other) {
-        ptr_ = other.ptr_;
-        invoker_ = other.invoker_;
-        return *this;
-    }
-    FuncPtr& operator =(ReturnType (*fn)(ArgTypes...)) {
-        assignStatic(fn);
-        return *this;
-    }
-    template <typename T>
-    FuncPtr& operator =(T* obj) {
-        assignFunctor(obj);
-        return *this;
-    }
-
-    explicit operator bool() const {
-        return !!ptr_;
-    }
-
-    ReturnType operator ()(ArgTypes... argv) const {
-        assert(ptr_ && invoker_);
-        return invoker_(ptr_, ke::Forward<ArgTypes>(argv)...);
-    }
-
-  private:
-    void assignStatic(ReturnType (*fn)(ArgTypes...)) {
-        typedef decltype(fn) FnType;
-        ptr_ = reinterpret_cast<void*>(fn);
-        invoker_ = [](void* ptr, ArgTypes&&... argv) {
-            return (reinterpret_cast<FnType>(ptr))(ke::Forward<ArgTypes>(argv)...);
-        };
-    }
-    template <typename T>
-    void assignFunctor(T* obj) {
-        ptr_ = obj;
-        invoker_ = [](void* ptr, ArgTypes&&... argv) {
-            return (reinterpret_cast<T*>(ptr))->operator()(ke::Forward<ArgTypes>(argv)...);
-        };
-    }
-
-  private:
-    void* ptr_;
-    Invoker invoker_;
 };
 
 } // namespace ke

--- a/amtl/experimental/am-argparser.h
+++ b/amtl/experimental/am-argparser.h
@@ -31,6 +31,7 @@
 
 #include <amtl/am-algorithm.h>
 #include <amtl/am-cxx.h>
+#include <amtl/am-function.h>
 #include <amtl/am-maybe.h>
 #include <amtl/am-string.h>
 #include <amtl/am-vector.h>

--- a/tests/AMBuild.tests
+++ b/tests/AMBuild.tests
@@ -44,6 +44,7 @@ compiler.linkflags.append(KE.libamtl)
 
 binary.sources += [
   'main.cpp',
+  'test-callable.cpp',
   'test-hashmap.cpp',
   'test-inlinelist.cpp',
   'test-linkedlist.cpp',

--- a/tests/test-callable.cpp
+++ b/tests/test-callable.cpp
@@ -70,11 +70,11 @@ class CallableObj
     }
 };
 
-TEST(Callable, BasicLambda) {
+TEST(Callable, BasicFunction) {
     int egg = 20;
     auto fn = [&egg](int x) -> int { return egg + x + 1; };
 
-    Lambda<int(int)> ptr(fn);
+    Function<int(int)> ptr(fn);
     EXPECT_EQ(ptr(10), 31);
 
     ptr = [](int x) -> int { return x + 15; };
@@ -87,7 +87,7 @@ TEST(Callable, BasicLambda) {
     ptr = obj;
     EXPECT_EQ(ptr(66), 100);
 
-    Lambda<unsigned(MoveObj && obj)> ptr2 = [](MoveObj&& obj) -> unsigned {
+    Function<unsigned(MoveObj && obj)> ptr2 = [](MoveObj&& obj) -> unsigned {
         MoveObj other(ke::Move(obj));
         return other.count();
     };
@@ -97,7 +97,7 @@ TEST(Callable, BasicLambda) {
 }
 
 TEST(Callable, InlineStorage) {
-    Lambda<int()> ptr = []() -> int { return 10; };
+    Function<int()> ptr = []() -> int { return 10; };
 
     EXPECT_TRUE(ptr.usingInlineStorage());
     EXPECT_EQ(ptr(), 10);
@@ -144,7 +144,7 @@ TEST(Callable, Move) {
     };
 
     CallDtorObj test_dtor;
-    Lambda<void()> ptr = [test_dtor] {};
+    Function<void()> ptr = [test_dtor] {};
 
     EXPECT_EQ(dtors, (size_t)1);
 
@@ -153,7 +153,7 @@ TEST(Callable, Move) {
     movectors = 0;
     dtors = 0;
 
-    Lambda<void()> ptr2 = ptr;
+    Function<void()> ptr2 = ptr;
     EXPECT_EQ(ctors, (size_t)0);
     EXPECT_EQ(copyctors, (size_t)1);
     EXPECT_EQ(movectors, (size_t)0);
@@ -161,7 +161,7 @@ TEST(Callable, Move) {
 
     copyctors = 0;
 
-    Lambda<void()> ptr3 = ke::Move(ptr2);
+    Function<void()> ptr3 = ke::Move(ptr2);
     EXPECT_EQ(ctors, (size_t)0);
     EXPECT_EQ(copyctors, (size_t)0);
     EXPECT_EQ(movectors, (size_t)0);
@@ -170,35 +170,9 @@ TEST(Callable, Move) {
     copyctors = 0;
 
     auto fn = [test_dtor] {};
-    Lambda<void()> ptr4 = ke::Move(fn);
+    Function<void()> ptr4 = ke::Move(fn);
     EXPECT_EQ(ctors, (size_t)0);
     EXPECT_EQ(copyctors, (size_t)1);
     EXPECT_EQ(movectors, (size_t)1);
     EXPECT_EQ(dtors, (size_t)0);
-}
-
-TEST(Callable, FuncPtr) {
-    FuncPtr<int(int)> ptr = test_old_fn;
-
-    EXPECT_EQ(ptr(1), 100);
-
-    auto fn = [](int x) -> int { return x + 2; };
-    ptr = &fn;
-
-    EXPECT_EQ(ptr(10), 12);
-
-    CallableObj obj;
-    ptr = &obj;
-    EXPECT_EQ(ptr(7), 41);
-}
-
-TEST(Callable, MoveUncopyable) {
-    Vector<int> v;
-
-    auto lambda = [v = Move(v)]() -> size_t { return v.length(); };
-
-    v.append(10);
-    Function<size_t()> f = ke::Move(lambda);
-
-    EXPECT_EQ(f(), (size_t)0);
 }

--- a/tests/test-callable.cpp
+++ b/tests/test-callable.cpp
@@ -1,0 +1,204 @@
+// vim: set sts=8 ts=2 sw=2 tw=99 et:
+//
+// Copyright (C) 2013, David Anderson and AlliedModders LLC
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  * Neither the name of AlliedModders LLC nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <amtl/am-function.h>
+#include <amtl/am-vector.h>
+#include <gtest/gtest.h>
+#include "runner.h"
+
+using namespace ke;
+
+static int
+test_old_fn(int x)
+{
+    return 99 + x;
+}
+
+class MoveObj
+{
+  public:
+    static unsigned sNumMoves;
+
+    MoveObj() {
+        sNumMoves = 0;
+    }
+    MoveObj(MoveObj&& other) {
+        sNumMoves++;
+    }
+
+    unsigned count() const {
+        return sNumMoves;
+    }
+
+  private:
+    MoveObj(const MoveObj& other);
+    void operator =(const MoveObj& other);
+};
+unsigned MoveObj::sNumMoves = 0;
+
+class CallableObj
+{
+  public:
+    int operator ()(int x) const {
+        return x + 34;
+    }
+};
+
+TEST(Callable, BasicLambda) {
+    int egg = 20;
+    auto fn = [&egg](int x) -> int { return egg + x + 1; };
+
+    Lambda<int(int)> ptr(fn);
+    EXPECT_EQ(ptr(10), 31);
+
+    ptr = [](int x) -> int { return x + 15; };
+    EXPECT_EQ(ptr(7), 22);
+
+    ptr = test_old_fn;
+    EXPECT_EQ(ptr(10), 109);
+
+    CallableObj obj;
+    ptr = obj;
+    EXPECT_EQ(ptr(66), 100);
+
+    Lambda<unsigned(MoveObj && obj)> ptr2 = [](MoveObj&& obj) -> unsigned {
+        MoveObj other(ke::Move(obj));
+        return other.count();
+    };
+
+    MoveObj moveObj;
+    EXPECT_EQ(ptr2(ke::Move(moveObj)), (unsigned)1);
+}
+
+TEST(Callable, InlineStorage) {
+    Lambda<int()> ptr = []() -> int { return 10; };
+
+    EXPECT_TRUE(ptr.usingInlineStorage());
+    EXPECT_EQ(ptr(), 10);
+
+    static size_t dtors = 0;
+    struct CallDtorObj {
+        ~CallDtorObj() {
+            dtors++;
+        }
+    };
+
+    struct {
+        int a;
+        void *b, *c, *d, *e, *f, *g;
+        void *h, *j, *k, *m, *n, *o, *p;
+    } huge_struct = {20};
+    CallDtorObj test_dtor;
+    ptr = [huge_struct, test_dtor]() -> int { return huge_struct.a; };
+    EXPECT_FALSE(ptr.usingInlineStorage());
+    EXPECT_EQ(ptr(), 20);
+
+    ptr = nullptr;
+    EXPECT_EQ(dtors, (size_t)2);
+}
+
+TEST(Callable, Move) {
+    static size_t ctors = 0;
+    static size_t copyctors = 0;
+    static size_t movectors = 0;
+    static size_t dtors = 0;
+    struct CallDtorObj {
+        CallDtorObj() {
+            ctors++;
+        }
+        CallDtorObj(const CallDtorObj& other) {
+            copyctors++;
+        }
+        CallDtorObj(CallDtorObj&& other) {
+            movectors++;
+        }
+        ~CallDtorObj() {
+            dtors++;
+        }
+    };
+
+    CallDtorObj test_dtor;
+    Lambda<void()> ptr = [test_dtor] {};
+
+    EXPECT_EQ(dtors, (size_t)1);
+
+    ctors = 0;
+    copyctors = 0;
+    movectors = 0;
+    dtors = 0;
+
+    Lambda<void()> ptr2 = ptr;
+    EXPECT_EQ(ctors, (size_t)0);
+    EXPECT_EQ(copyctors, (size_t)1);
+    EXPECT_EQ(movectors, (size_t)0);
+    EXPECT_EQ(dtors, (size_t)0);
+
+    copyctors = 0;
+
+    Lambda<void()> ptr3 = ke::Move(ptr2);
+    EXPECT_EQ(ctors, (size_t)0);
+    EXPECT_EQ(copyctors, (size_t)0);
+    EXPECT_EQ(movectors, (size_t)0);
+    EXPECT_EQ(dtors, (size_t)0);
+
+    copyctors = 0;
+
+    auto fn = [test_dtor] {};
+    Lambda<void()> ptr4 = ke::Move(fn);
+    EXPECT_EQ(ctors, (size_t)0);
+    EXPECT_EQ(copyctors, (size_t)1);
+    EXPECT_EQ(movectors, (size_t)1);
+    EXPECT_EQ(dtors, (size_t)0);
+}
+
+TEST(Callable, FuncPtr) {
+    FuncPtr<int(int)> ptr = test_old_fn;
+
+    EXPECT_EQ(ptr(1), 100);
+
+    auto fn = [](int x) -> int { return x + 2; };
+    ptr = &fn;
+
+    EXPECT_EQ(ptr(10), 12);
+
+    CallableObj obj;
+    ptr = &obj;
+    EXPECT_EQ(ptr(7), 41);
+}
+
+TEST(Callable, MoveUncopyable) {
+    Vector<int> v;
+
+    auto lambda = [v = Move(v)]() -> size_t { return v.length(); };
+
+    v.append(10);
+    Function<size_t()> f = ke::Move(lambda);
+
+    EXPECT_EQ(f(), (size_t)0);
+}


### PR DESCRIPTION
Removing this was a little premature as it turns out SourceMod uses it
across module boundaries. We cannot use STL across module boundaries.

Instead, simplify this quite a bit. Remove FuncPtr (which was unused),
and rename Lambda to Function, removing the old Function implementation.
This makes it basically identical to std::function including the caveat
that captures must be copy constructable.