### PR TITLE
Remove AString and replace uses with std::string.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -9,13 +9,6 @@ class KEConfig(object):
   def configure(self):
     cxx = builder.DetectCxx()
 
-    # if cxx.version < 'clang-3.0' or cxx.version < 'apple-clang-3.0':
-    #   raise Exception('AMTL requires clang 3.0 or higher.')
-    # if cxx.version < 'gcc-4.5':
-    #   raise Exception('AMTL requires GCC 4.5 or higher.')
-    # if cxx.version < 'msvc-1600':
-    #   raise Exception('AMTL requires Visual Studio 2010 (CL 16.00) or higher.')
-
     if cxx.like('gcc'):
       if builder.target.platform != 'windows':
         cxx.cxxflags += ['-std=c++14']
@@ -47,6 +40,8 @@ class KEConfig(object):
       cxx.cxxflags += ['-Wno-unused-function']
       if cxx.like('clang'):
         cxx.cxxflags += ['-Wno-implicit-exception-spec-mismatch']
+      elif cxx.like('gcc'):
+        cxx.cxxflags += ['-Wformat-truncation=0']
 
       cxx.cxxflags += [
         '-fno-exceptions',
@@ -121,9 +116,9 @@ class KEConfig(object):
         cxx.linkflags += ['-lgcc_eh']
     elif builder.target.platform == 'mac':
       cxx.defines += ['OSX', '_OSX', 'POSIX']
-      cxx.cflags += ['-mmacosx-version-min=10.9']
+      cxx.cflags += ['-mmacosx-version-min=10.7']
       cxx.linkflags += [
-        '-mmacosx-version-min=10.9',
+        '-mmacosx-version-min=10.7',
         '-lstdc++',
         '-stdlib=libc++',
       ]

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ systems code. It is the spiritual succesor to the SourceHook template library.
 
 AMBuild currently requires C++11 support. The minimum supported compiler versions are:
  - Microsoft Visual Studio 2015 or higher.
- - GNU GCC 4.9 or higher.
  - Clang 3.5 or higher.
+ - GNU GCC 4.9 or higher.
 
 To build tests, C++14 or higher is required (on macOS, the minimum version is OS X 10.9).
 
@@ -195,11 +195,6 @@ backward compatibility, and it should be avoided in general, except in situation
 absolutely necessary and allocation performance is not a factor. Otherwise, use InlineList or
 Vector.
 
-### Strings (am-string.h)
-
-The String API is still rather in flux. Currently, a simple std::string-like class is provided
-called AString (short for ASCII String).
-
 ### FixedArray (am-fixedarray.h)
 
 FixedArray&lt;T, AP&gt; is a stripped-down version of Vector that is constructed with a fixed
@@ -232,10 +227,7 @@ pretty similar. Any missing methods could be added quite easily.
 
 ### String (sh\_string.h)
 
-String can be replaced with ke::AString, however some methods like trim() are not available yet.
-One notable difference is that AString caches the length of the string, whereas SH::String does
-not. That means AString is a larger data structure (by 4 bytes, on 32-bit), but is not prone to
-O(n^2) operations like String. This more closely matches the functionality of std::string.
+String can be replaced with std::string.
 
 ### List (sh\_list.h)
 

--- a/amtl/am-vector.h
+++ b/amtl/am-vector.h
@@ -270,8 +270,10 @@ class Vector : private AllocPolicy
         T* newdata = (T*)this->am_malloc(sizeof(T) * new_maxsize);
         if (newdata == nullptr)
             return false;
-        for (size_t i = 0; i < nitems_; i++)
+        for (size_t i = 0; i < nitems_; i++) {
             new (&newdata[i]) T(std::move(data_[i]));
+            data_[i].~T();
+        }
         this->am_free(data_);
 
         data_ = newdata;

--- a/tests/test-argparser.cpp
+++ b/tests/test-argparser.cpp
@@ -114,7 +114,7 @@ TEST(ArgParser, StringArg) {
     Parser parser("help");
 
     StringOption s(parser, "s", "string", Nothing(), "help");
-    StringOption t(parser, "t", "ttt", Some(AString("whatever")), "help");
+    StringOption t(parser, "t", "ttt", Some(std::string("whatever")), "help");
     StringOption mode(parser, "mode", "help");
 
     parser.reset();
@@ -148,11 +148,11 @@ TEST(ArgParser, IntArg) {
 TEST(ArgParser, RepeatArg) {
     Parser parser("help");
 
-    RepeatOption<AString> inc(parser, "-i", "--include-path", "Include path.");
+    RepeatOption<std::string> inc(parser, "-i", "--include-path", "Include path.");
 
     ASSERT_TRUE(parser.parsev("-i", "blah", "-i", "crab", "--include-path=yam", nullptr));
 
-    Vector<AString> values = std::move(inc.values());
+    Vector<std::string> values = std::move(inc.values());
     ASSERT_EQ(values.length(), (size_t)3);
     EXPECT_EQ(values[0].compare("blah"), 0);
     EXPECT_EQ(values[1].compare("crab"), 0);

--- a/tests/test-hashmap.cpp
+++ b/tests/test-hashmap.cpp
@@ -39,13 +39,13 @@ struct StringPolicy {
     static inline uint32_t hash(const char* key) {
         return FastHashCharSequence(key, strlen(key));
     }
-    static inline bool matches(const char* find, const AString& key) {
+    static inline bool matches(const char* find, const std::string& key) {
         return key.compare(find) == 0;
     }
 };
 
 TEST(HashMap, Basic) {
-    typedef HashMap<AString, int, StringPolicy> Map;
+    typedef HashMap<std::string, int, StringPolicy> Map;
     Map map;
 
     ASSERT_TRUE(map.init());
@@ -55,7 +55,7 @@ TEST(HashMap, Basic) {
 
     Map::Insert i = map.findForAdd("cat");
     ASSERT_FALSE(i.found());
-    ASSERT_TRUE(map.add(i, AString("cat"), 5));
+    ASSERT_TRUE(map.add(i, std::string("cat"), 5));
     EXPECT_EQ(r->value, 5);
 
     Map::iterator iter = map.iter();
@@ -80,7 +80,7 @@ TEST(HashMap, Basic) {
 }
 
 TEST(HashMap, Bug6527) {
-    typedef HashMap<AString, int, StringPolicy> Map;
+    typedef HashMap<std::string, int, StringPolicy> Map;
     Map map;
 
     ASSERT_TRUE(map.init(16));

--- a/tests/test-string.cpp
+++ b/tests/test-string.cpp
@@ -48,15 +48,15 @@ TEST(String, Allocating) {
     std::unique_ptr<char[]> ptr = Sprintf("A: %d B: %s", a, value);
     EXPECT_EQ(strcmp(ptr.get(), expect), 0);
 
-    std::unique_ptr<AString> str = AString::Sprintf("A: %d B: %s", a, value);
-    EXPECT_EQ(str->compare(expect), 0);
+    auto str = StringPrintf("A: %d B: %s", a, value);
+    EXPECT_EQ(str, expect);
 }
 
 TEST(String, Split) {
-    Vector<AString> out = Split("     ", " ");
+    auto out = Split("     ", " ");
     EXPECT_EQ(out.length(), (size_t)6);
     for (size_t i = 0; i < out.length(); i++) {
-        EXPECT_EQ(out[i].length(), (size_t)0);
+        EXPECT_EQ(out[i].size(), (size_t)0);
     }
 
     out = Split("egg", " ");
@@ -79,35 +79,30 @@ TEST(String, Split) {
 }
 
 TEST(String, Join) {
-    Vector<AString> in;
+    Vector<std::string> in;
 
-    AString result = Join(in, "x");
-    EXPECT_EQ(result.compare(""), 0);
+    auto result = Join(in, "x");
+    EXPECT_EQ(result, "");
 
     in.append("abc");
     result = Join(in, "x");
-    EXPECT_EQ(result.compare("abc"), 0);
+    EXPECT_EQ(result, "abc");
 
     in.append("xyz");
     result = Join(in, "T");
-    EXPECT_EQ(result.compare("abcTxyz"), 0);
+    EXPECT_EQ(result, "abcTxyz");
 
     in.append("def");
     result = Join(in, "");
-    EXPECT_EQ(result.compare("abcxyzdef"), 0);
+    EXPECT_EQ(result, "abcxyzdef");
 }
 
 TEST(String, Case) {
-    AString str("samPle1.com");
-    str = str.uppercase();
-    EXPECT_EQ(str.compare("SAMPLE1.COM"), 0);
+    const char* str = "samPle1.com";
+    EXPECT_EQ(Uppercase(str), "SAMPLE1.COM");
+    EXPECT_EQ(Lowercase(str), "sample1.com");
 
-    str = str.lowercase();
-    EXPECT_EQ(str.compare("sample1.com"), 0);
-
-    str = AString();
-    str = str.lowercase();
-    EXPECT_EQ(str.compare(""), 0);
+    EXPECT_EQ(Lowercase(""), "");
 }
 
 TEST(String, StrCpy) {
@@ -127,12 +122,12 @@ TEST(String, StrCpy) {
 }
 
 TEST(String, StartsWith) {
-    AString str("blah");
+    std::string str("blah");
 
-    EXPECT_TRUE(str.startsWith("b"));
-    EXPECT_TRUE(str.startsWith("blah"));
-    EXPECT_FALSE(str.startsWith("a"));
-    EXPECT_FALSE(str.startsWith("blah2"));
+    EXPECT_TRUE(StartsWith(str, "b"));
+    EXPECT_TRUE(StartsWith(str, "blah"));
+    EXPECT_FALSE(StartsWith(str, "a"));
+    EXPECT_FALSE(StartsWith(str, "blah2"));
 }
 
 TEST(String, SafeStrcat) {


### PR DESCRIPTION
It's difficult to mix AString with third-party C++ code that uses
std::string. The only advantage AString provides is being able to
transfer ownership of the underlying buffer, but that is not enough to
warrant maintaining this half-implemented class.