### PR TITLE
Updated 'checkout-deps' to check for 'pip'/'pip3' prior to installing 'AMBuild'

### DIFF
--- a/.appveyor/build.bat
+++ b/.appveyor/build.bat
@@ -2,6 +2,6 @@
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 mkdir opt32 && cd opt32
 C:\python27\python.exe ..\configure.py --enable-optimize
-C:\python27\python.exe C:\python27\Scripts\ambuild
+ambuild
 cd ..
 opt32\tests\testrunner\testrunner.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
 
     - os: osx
-      osx_image: xcode6.4
+      osx_image: xcode12
       sudo: true
       language: cpp
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
 
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode6.4
       sudo: true
       language: cpp
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages: ['clang-3.8', 'lib32stdc++6', 'lib32z1-dev', 'libc6-dev-i386', 'linux-libc-dev:i386', 'g++-4.9-multilib']
       env:
+        - PATH="~/.local/bin:$PATH"
         - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
 
     - os: linux
@@ -29,6 +30,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages: ['clang-3.4', 'lib32stdc++6', 'lib32z1-dev', 'libc6-dev-i386', 'linux-libc-dev:i386', 'g++-4.9-multilib']
       env:
+        - PATH="~/.local/bin:$PATH"
         - MATRIX_EVAL="CC=clang && CXX=clang++"
 
     - os: osx
@@ -36,6 +38,7 @@ matrix:
       sudo: true
       language: cpp
       env:
+        - PATH="~/Library/Python/2.7/bin:$PATH"
         - MATRIX_EVAL="CC=clang && CXX=clang++"
 
     - os: linux
@@ -46,6 +49,7 @@ matrix:
         apt:
           packages: ['lib32stdc++6', 'lib32z1-dev', 'libc6-dev-i386', 'linux-libc-dev:i386', 'g++-multilib', 'clang']
       env:
+        - PATH="~/.local/bin:$PATH"
         - MATRIX_EVAL="CC=clang && CXX=clang++"
 
     - os: linux
@@ -56,12 +60,12 @@ matrix:
         apt:
           packages: ['lib32stdc++6', 'lib32z1-dev', 'libc6-dev-i386', 'linux-libc-dev:i386', 'g++-multilib', 'g++']
       env:
+        - PATH="~/.local/bin:$PATH"
         - MATRIX_EVAL="CC=gcc && CXX=g++"
 
 before_script:
   - CHECKOUT_DIR=$PWD && cd .. && $CHECKOUT_DIR/checkout-deps.sh && cd $CHECKOUT_DIR
 script:
-  - PATH="~/.local/bin:$PATH"
   - eval "${MATRIX_EVAL}"
   - eval "${CC} --version"
   - eval "${CXX} --version"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
 
     - os: osx
-      osx_image: xcode12
+      osx_image: xcode7.3
       sudo: true
       language: cpp
       env:

--- a/checkout-deps.sh
+++ b/checkout-deps.sh
@@ -53,9 +53,9 @@ if [ $? -eq 1 ]; then
     get_pip_url="https://bootstrap.pypa.io/get-pip.py"
 
     if [ `command -v wget` ]; then
-      wget $get_pip_url -O $get_pip
+      wget $get_pip_url -O $get_pip --no-check-certificate 
     elif [ `command -v curl` ]; then
-      curl -o $get_pip $get_pip_url
+      curl -o $get_pip $get_pip_url --insecure 
     else
       echo "Failed to locate wget or curl. Install one of these programs to download 'get-pip.py'."
       exit 1

--- a/checkout-deps.sh
+++ b/checkout-deps.sh
@@ -30,22 +30,54 @@ checkout ()
   fi
 }
 
-`python -c "import ambuild2"`
+python_cmd=`command -v python`
+if [ -z "$python_cmd" ]; then
+  python_cmd=`command -v python3`
+
+  if [ -z "$python_cmd" ]; then
+    echo "No suitable installation of Python detected"
+    exit 1
+  fi
+fi
+
+`$python_cmd -c "import ambuild2"` 2>&1 1>/dev/null
 if [ $? -eq 1 ]; then
+  echo "AMBuild is required to build AMTL"
+
+  `$python_cmd -m pip --version` 2>&1 1>/dev/null
+  if [ $? -eq 1 ]; then
+    echo "The detected Python installation does not have PIP"
+    echo "Installing the latest version of PIP available (VIA \"get-pip.py\")"
+
+    get_pip="./get-pip.py"
+    get_pip_url="https://bootstrap.pypa.io/get-pip.py"
+
+    if [ `command -v wget` ]; then
+      wget $get_pip_url -O $get_pip
+    elif [ `command -v curl` ]; then
+      curl -o $get_pip $get_pip_url
+    else
+      echo "Failed to locate wget or curl. Install one of these programs to download 'get-pip.py'."
+      exit 1
+    fi
+
+    $python_cmd $get_pip
+    if [ $? -eq 1 ]; then
+      echo "Installation of PIP has failed"
+      exit 1
+    fi
+  fi
+
   repo="https://github.com/alliedmodders/ambuild"
   origin=
   branch=master
   name=ambuild
   checkout
 
-  cd ambuild
-  if [ $iswin -eq 1 ]; then
-    python setup.py install
-  elif [ $ismac -eq 1 ]; then
-    sudo python setup.py install
+  if [ $iswin -eq 1 ] || [ $ismac -eq 1 ]; then
+    $python_cmd -m pip install ./ambuild
   else
-    python setup.py build
     echo "Installing AMBuild at the user level. Location can be: ~/.local/bin"
-    python setup.py install --user
+    $python_cmd -m pip install --user ./ambuild
   fi
 fi


### PR DESCRIPTION
## checkout-deps.sh:
   - Checks for an active 'python'/'python3' command.
   - Checks for an active pip installation in the detected Python installation, otherwise, it installs it via 'get-pip.py'

See: alliedmodders/ambuild#68