### PR TITLE
Fix argparser StopOption still requiring positional arguments

### DIFF
--- a/amtl/experimental/am-argparser.h
+++ b/amtl/experimental/am-argparser.h
@@ -611,6 +611,7 @@ inline bool
 Parser::parse_impl(const std::vector<const char*>& args)
 {
     size_t positional = 0;
+    bool halted_on_value = false;
 
     for (size_t i = 0; i < args.size(); i++) {
         const char* arg = args[i];
@@ -701,11 +702,13 @@ Parser::parse_impl(const std::vector<const char*>& args)
                 i--;
         }
 
-        if (option->haltOnValue())
+        if (option->haltOnValue()) {
+            halted_on_value = true;
             break;
+        }
     }
 
-    if (positional < positionals_.size())
+    if (!halted_on_value && positional < positionals_.size())
         return missing_positional(positionals_[positional]);
 
     // Force the app to display a help message.

--- a/tests/test-argparser.cpp
+++ b/tests/test-argparser.cpp
@@ -126,7 +126,7 @@ TEST(ArgParser, StopArg1) {
     StringOption required(parser, "something_required", "This is a required positional argument.");
 
     EXPECT_FALSE(parser.parsev(nullptr));
-    EXPECT_FALSE(parser.parsev("-v", nullptr));
+    EXPECT_TRUE(parser.parsev("-v", nullptr));
     EXPECT_TRUE(show_version.value());
 }
 
@@ -136,7 +136,7 @@ TEST(ArgParser, StopArg2) {
     StopOption show_version(parser, "-v", "--version", Some(false), "Show the version and exit.");
     StringOption filename(parser, "file", "SMX file to execute.");
 
-    EXPECT_FALSE(parser.parsev("-v", "-w", nullptr));
+    EXPECT_TRUE(parser.parsev("-v", "-w", nullptr));
     EXPECT_TRUE(show_version.value());
 }
 


### PR DESCRIPTION
Even after encountering a StopOption, the parser would check if there are enough positional parameters leading to a different error message than what the implementor wanted for the StopOption.