### PR TITLE
Use python33 to build ambuild in appveyor

### DIFF
--- a/.appveyor/build.bat
+++ b/.appveyor/build.bat
@@ -1,7 +1,7 @@
 @echo on
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 mkdir opt32 && cd opt32
-C:\python27\python.exe ..\configure.py --enable-optimize
+python ..\configure.py --enable-optimize
 ambuild
 cd ..
 opt32\dist\testrunner.exe

--- a/.appveyor/setup_environment.bat
+++ b/.appveyor/setup_environment.bat
@@ -1,6 +1,7 @@
 @echo on
+SET PYTHON=c:\python33
+SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
 git submodule update --init
 git clone https://github.com/alliedmodders/ambuild ambuild
-cd ambuild
-c:\python27\python.exe setup.py install
+pip install ./ambuild
 chdir /D "%APPVEYOR_BUILD_FOLDER%"


### PR DESCRIPTION
The pipeline is failing, I suspect it's because ambuild requires python 3.3 or higher, this changes .appveyor to use python 3.3 to build ambuild in the 'setup_environment.bat' 

https://github.com/alliedmodders/ambuild
https://www.appveyor.com/docs/windows-images-software/#python:~:text=Python%203.3.5%20x86%20(-,C%3A%5CPython33,-)