### PR TITLE
Fix compilation error with C++23

### DIFF
--- a/amtl/am-string.h
+++ b/amtl/am-string.h
@@ -181,7 +181,7 @@ StringPrintfVa(const char* fmt, va_list ap)
     size_t len;
     std::unique_ptr<char[]> result = detail::SprintfArgsImpl(&len, fmt, ap);
     if (!result)
-        return nullptr;
+        return "";
     return std::string(result.get(), len);
 }
 


### PR DESCRIPTION
Before fix it gives this error:
```
amtl/am-string.h:184:16: error: conversion function from 'std::nullptr_t' to 'std::string' (aka 'basic_string<char>') invokes a deleted function
  184 |         return nullptr;
```

Returning an empty string fixes the problem and works as intended according to this:
> There are several possible ways to fix this code; you could pass an empty string with "" or std::string{} or even {} (depending on whether open_choices() is overloaded).

from https://github.com/mamedev/mame/issues/8265